### PR TITLE
feat(semantic): `take .active from .tab for me` — the recipient role the en reference silently dropped

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -2904,33 +2904,60 @@ The two headlines for this side:
   `for` was an unconsumed-tail artifact and the duration role removes it. The
   corpus row parses faithfully in all 24 and needs no allowlist entry.
 
-## `take` has no `recipient` role — the en reference drops `for me` (opened 2026-07-31)
+## ~~`take` has no `recipient` role — the en reference drops `for me`~~ — SHIPPED (2026-07-31), 10-language tail open
 
-Found while fixing the core-side `take` rejection (PARSER_NEXT_STEPS.md § the
-take table). `takeSchema` models `patient` + `source` only, so the semantic
-parser matches `take .active from .tab-button for me` at **confidence 1.0**
-while leaving `"for me"` unconsumed — the `unconsumed-input` warning
-diagnostic is the only tell. The corpus row `take-class-from-siblings` is
-EXACTLY this surface, which means:
+The en half is FIXED. `takeSchema` now declares a `recipient` role
+(`markerOverride: { en: 'for' }`, `expectedTypes: ['reference']`,
+`valueShape: 'reference'`) wired to `ast.modifiers.for`, which core's
+`TakeCommand.parseInput` has read since #859 — so no runtime change was
+needed. `take .active from .tab-button for me` now captures
+`recipient=me` at confidence 1.0 with **no `unconsumed-input` diagnostic**,
+and the en reference of `take-class-from-siblings` carries the role.
 
-- The **en reference parse itself drops the recipient**, so every language
-  matches the dropped reference and R0/R1/R3 all score a perfect 1.0 — the
-  documented en-reference blind spot, live on a real corpus row. No current
-  signal can see it (R3's firestorm inversion doesn't fire because the
-  recipient is `me`, not a language-invariant value).
-- Core-side this is now harmless in ENGLISH — `take` sits on
-  `skipSemanticParsing`, so the traditional parser handles the `for` tail —
-  but any consumer of the semantic parse alone (multilingual bundles, the
-  bridge, translate()) silently loses the recipient in all 24 languages.
+**The blind spot this closed**: the en reference parse itself dropped the
+recipient, so every language matched the dropped reference and R0/R1/R3 all
+scored a perfect 1.0. Nothing but the diagnostic could see it (R3's firestorm
+inversion does not fire — the recipient is `me`, not a language-invariant
+value). English execution was never affected; `take` remains on
+`skipSemanticParsing` because upstream also accepts element-EXPRESSION
+recipients, which the reference-typed semantic slot deliberately refuses.
 
-The work, when taken: a `recipient` role on `takeSchema` (upstream's `for`
-clause), per-language markers (the `for`-word history in the toggle-for brief
-above is directly relevant — `for` collides with the LOOP keyword in several
-languages; bn `জন্য` was measured particle-safe there), i18n transformer
-rendering, and a baseline regen. Until then the schema's `source` role also
-carries a warning: its `default: me` was REMOVED 2026-07-31 (bare
-`take .active` must mean "take from all current holders", not "take from me")
-— do not reinstate it when adding the recipient.
+**Two premises in the original filing were wrong, and measurement is why:**
+
+1. _"per-language markers"_ — not needed, and not possible from the stored
+   surfaces. All 23 non-en corpus rows render the recipient as a **bare
+   trailing pronoun** (`… von .tab-button ich`, `… から 私`, `… 从 .tab-button
+   我`) because i18n suppresses the marker for pronoun-valued `for` phrases
+   (`grammar/types.ts` `insertMarkers`). A marker would match nothing. Read the
+   STORED patterns.db rows, not `translate()` — the two renderers disagree, and
+   the retracted toggle-for marker table is the precedent.
+2. _"i18n transformer rendering"_ — deliberately NOT done. It would rewrite all
+   23 stored surfaces and fan out into grammar tests, V2/V4 vocab, R4 and every
+   other pronoun-carrying pattern. Deferred as per-language opt-in work.
+
+**Measured outcome** (whole-corpus probe, 3960 rows = every pattern × every
+language, pre vs post): **14 languages capture** the marker-less trailing
+pronoun — en ar de es fr he id ms pl pt sw th tl zh — and **10 do not**: bn hi
+it ja ko qu ru tr uk vi. **Zero diffs anywhere else in the corpus.** The 10 are
+"passive defer": the empty slot perturbs nothing, so no inert particle was
+needed (toggle's ja `間` / ko `동안` case did not recur). They are recorded in
+the baseline's `roleLossyPatterns` — the named R1 burn-down tail, each worth
+exactly 0.0013 of that language's avgRoleFidelity. Both the captured and
+deferred lists are pinned in `packages/semantic/test/take-recipient.test.ts`,
+so a language starting to capture is a visible test failure, not a silent
+drift: move it to CAPTURED and regenerate the baseline in the same change.
+
+`valueShape: 'reference'` is the second shape-anchor kind and it is
+load-bearing — **measured under mutation**: deleting it drops plain
+`take .active from .tab-button` from 1.0 to **0.6923**, below the 0.7
+adoption threshold, the same 1.0 → 0.69 number toggle's duration produced.
+(The first version of that test asserted through `parse(...).confidence`, which
+is `undefined`, and passed vacuously under the mutation — it now goes through
+`parseSemantic`.)
+
+Still standing: `source` has **no** `default: me` and must not get one — bare
+`take .active` means "take from all current holders" (#859). Recipient is
+default-free for the mirror reason: the runtime supplies `me` itself.
 
 ## `process` has no view-transition role — the tail is dropped (opened 2026-07-31)
 

--- a/docs-internal/PARSER_NEXT_STEPS.md
+++ b/docs-internal/PARSER_NEXT_STEPS.md
@@ -316,12 +316,15 @@ current holder when `from` is absent — then add to the recipient, default
 (bare `take .active` parsed as a near-no-op "take from me"). The non-class
 value-transfer forms keep hyperfixi's semantics. e2e both paths:
 `packages/core/src/commands/animation/__tests__/take-from-for.test.ts`.
+The semantic schema's `recipient` role SHIPPED 2026-07-31 (see
+MULTILINGUAL_NEXT_STEPS.md): the en reference for `take-class-from-siblings` no
+longer drops `for me`, and 14 of 24 languages capture it. `take` nonetheless
+STAYS on `skipSemanticParsing` — the semantic slot is reference-typed
+(`for me`), so upstream's element-EXPRESSION recipients still need the
+traditional parser.
 Still open, deliberately: upstream's `with <classRef>` / `giving <expr>`
-replacement forms (error rather than mis-parse), the `and put it on` tail
-(never parseable — pre-existing, programmatic-AST only), and the semantic
-schema's missing `recipient` role (queued in MULTILINGUAL_NEXT_STEPS.md — the
-en reference for `take-class-from-siblings` silently drops `for me`, the
-`unconsumed-input` warning at confidence 1.0 is the tell).
+replacement forms (error rather than mis-parse) and the `and put it on` tail
+(never parseable — pre-existing, programmatic-AST only).
 
 Two adjacent diagnostics found in the same sweep, both cosmetic and neither
 worth its own arc — fold them into whichever change touches this area:

--- a/packages/core/src/parser/parser.ts
+++ b/packages/core/src/parser/parser.ts
@@ -3445,10 +3445,12 @@ export class Parser {
     //   - toggle: `.class` / `@attr` / `*property` argument references —
     //     semantic parsing drops the prefix, so `toggle @disabled` loses the
     //     attribute reference (sibling of add / remove, which are also here)
-    //   - take: same family as toggle/add/remove, plus a `for <recipient>`
-    //     tail the semantic schema does not model — the semantic match left
-    //     `for me` unconsumed, skipToCommandBoundary() stopped at `for` (a
-    //     command token), and the next round parsed it as a for LOOP
+    //   - take: same family as toggle/add/remove. It also carries a
+    //     `for <recipient>` tail: the semantic match used to leave `for me`
+    //     unconsumed, skipToCommandBoundary() stopped at `for` (a command
+    //     token), and the next round parsed it as a for LOOP. takeSchema now
+    //     models `recipient`, but only as a REFERENCE (`for me`) — upstream's
+    //     element-expression recipients still need this path
     //   - if / unless: condition role + multi-branch bodies
     //   - make / measure / trigger / halt / remove / exit / return / closest:
     //     each carries hyperscript-specific shape that semantic doesn't capture

--- a/packages/hyperscript-adapter/src/generated/syntax-table.ts
+++ b/packages/hyperscript-adapter/src/generated/syntax-table.ts
@@ -65,7 +65,7 @@ export const SYNTAX: Record<string, readonly [string, string][]> = {
   show: [['patient', ''], ['style', 'with']],
   socket: [],
   swap: [['method', ''], ['destination', 'of'], ['patient', 'with']],
-  take: [['patient', ''], ['source', 'from']],
+  take: [['patient', ''], ['source', 'from'], ['recipient', 'for']],
   tell: [['destination', '']],
   throw: [['patient', '']],
   toggle: [['patient', ''], ['destination', 'on'], ['duration', 'for']],

--- a/packages/hyperscript-adapter/test/derive-syntax.test.ts
+++ b/packages/hyperscript-adapter/test/derive-syntax.test.ts
@@ -48,6 +48,13 @@ describe('deriveEnglishSyntax', () => {
       ['patient', ''],
       ['source', 'from'],
     ]);
+    expect(derived.take).toEqual([
+      ['patient', ''],
+      ['source', 'from'],
+      // `take .active from .tab for me` — both ends of the transfer are named.
+      // The recipient is en-marked only; 23 languages render it unmarked.
+      ['recipient', 'for'],
+    ]);
   });
 
   it('derives content commands correctly', () => {

--- a/packages/i18n/src/grammar/types.ts
+++ b/packages/i18n/src/grammar/types.ts
@@ -66,6 +66,10 @@ export type SemanticRole =
   | 'source' // Origin (from #input, from URL)
   | 'destination' // Target location (into #output, to .class)
   | 'goal' // Target value/state (to 'red', to 100)
+  | 'recipient' // Who receives what the action transfers (take .active from .tab for me).
+  //              Declared for parity with the semantic union; NO i18n profile marks it yet
+  //              — en still maps `for` to duration lexically and suppresses the marker for
+  //              pronoun values (see insertMarkers below).
   | 'event' // Trigger (click, input, keydown)
   | 'condition' // Boolean expression (if x > 5)
   // Quantitative roles

--- a/packages/mcp-server/src/tools/language-docs.ts
+++ b/packages/mcp-server/src/tools/language-docs.ts
@@ -788,6 +788,15 @@ const ROLE_CATALOG: Record<
     commands: ['remove', 'on', 'get', 'take', 'pick', 'repeat', 'for', 'measure', 'fetch'],
     explicitExample: '[fetch source:/api/data responseType:json]',
   },
+  recipient: {
+    name: 'recipient',
+    description: 'Who receives what the action transfers — the far end of a transfer.',
+    origin: 'Linguistic thematic role: the beneficiary/goal of a transfer.',
+    usage:
+      "The element a class moves ONTO in `take` (its patient moves OFF the source), so both ends are named. Marked with `for` in English; most languages render it as a bare trailing pronoun.",
+    commands: ['take'],
+    explicitExample: '[take patient:.active source:.tab-button recipient:me]',
+  },
   event: {
     name: 'event',
     description: 'The trigger event for an event handler.',
@@ -816,8 +825,8 @@ const ROLE_CATALOG: Record<
     name: 'duration',
     description: 'A time span for the action.',
     origin: 'Temporal adverbial role.',
-    usage: 'How long a transition takes.',
-    commands: ['transition'],
+    usage: 'How long a transition takes, or how long a toggled class stays on before reverting.',
+    commands: ['transition', 'toggle'],
     explicitExample: '[transition patient:opacity duration:500ms]',
   },
   goal: {

--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -47,11 +47,17 @@ export interface RoleSpec {
   readonly markerOverride?: Record<string, string>;
   /**
    * Mark this role as SHAPE-ANCHORED: its surface form is unambiguous on its
-   * own (`'time'` = a unit-suffixed time literal — `2s`, `500ms`, `1.5s`), so
-   * the slot needs no marker to be safe. Enforced in the CONFIDENCE model
-   * (`scoreRoleCoverage`): a shape-anchored role counts toward a pattern's
-   * score only when captured, so an uncaptured optional slot carries no
-   * evidence against the pattern.
+   * own, so the slot needs no marker to be safe. Two kinds:
+   *
+   * - `'time'` — a unit-suffixed time literal (`2s`, `500ms`, `1.5s`).
+   * - `'reference'` — a CLOSED-CLASS context reference (`me`, `it`, `you` and
+   *   their per-language equivalents). Closed-class is the whole argument: the
+   *   tokenizer already classifies these as references, so a reference-typed
+   *   slot cannot swallow a selector or a literal.
+   *
+   * Enforced in the CONFIDENCE model (`scoreRoleCoverage`): a shape-anchored
+   * role counts toward a pattern's score only when captured, so an uncaptured
+   * optional slot carries no evidence against the pattern.
    *
    * This is the lever that makes a MARKER-LESS optional slot safe. Without it,
    * toggle's trailing `[{duration}]` weighed into every toggle pattern's
@@ -69,7 +75,7 @@ export interface RoleSpec {
    * spurious capture possible again, reinstate it THERE with a failing test
    * first.
    */
-  readonly valueShape?: 'time';
+  readonly valueShape?: 'time' | 'reference';
   /**
    * Make this role's object marker OPTIONAL in the generated pattern (wrapped in
    * an optional group), per language, so both the marked and unmarked surface forms
@@ -421,7 +427,6 @@ export const toggleSchema: CommandSchema = {
   category: 'dom-class',
   primaryRole: 'patient',
   // `toggle .active on #btn for 2s` → args ['.active'], modifiers { on, for }.
-  // NOTE: `duration` is read here but not declared in `roles` below.
   ast: { args: ['patient'], modifiers: { on: 'destination', for: 'duration' } },
   roles: [
     {
@@ -1592,8 +1597,8 @@ export const takeSchema: CommandSchema = {
   description: 'Take content from a source element',
   category: 'dom-content',
   primaryRole: 'patient',
-  // `take .active from #parent` → args ['.active'], modifiers { from: '#parent' }.
-  ast: { args: ['patient'], modifiers: { from: 'source' } },
+  // `take .active from #parent for me` → args ['.active'], modifiers { from, for }.
+  ast: { args: ['patient'], modifiers: { from: 'source', for: 'recipient' } },
   roles: [
     {
       role: 'patient',
@@ -1616,6 +1621,38 @@ export const takeSchema: CommandSchema = {
       expectedTypes: ['selector', 'reference'],
       svoPosition: 2,
       sovPosition: 1,
+    },
+    {
+      role: 'recipient',
+      description: 'The element the class moves ONTO (`take .active from .tab for me`)',
+      required: false,
+      // References only, deliberately. Upstream accepts an element expression,
+      // but the 23 non-en corpus surfaces carry the recipient as a BARE
+      // trailing pronoun (i18n renders `… von .tab-button ich`), so this slot
+      // is marker-less almost everywhere and a selector-typed slot would
+      // swallow the second selector of `take .active from .a .b`. English is
+      // unaffected: `take` is on the core parser's skipSemanticParsing list,
+      // so the traditional parser owns `for <anything>` there.
+      expectedTypes: ['reference'],
+      svoPosition: 3,
+      sovPosition: 3,
+      // NO default. The runtime already defaults the recipient to `me`
+      // (commands/animation/take.ts), and a schema default would emit an
+      // explicit `for me` modifier on every take — re-smuggling the exact
+      // "absent means absent" semantics #859 removed from `source`.
+      //
+      // Shape-anchored on `reference`: without it this optional slot weighs
+      // into every take pattern's denominator in `scoreRoleCoverage`, dropping
+      // plain `take .active from .tab-button` from 1.0 to ~0.69 — the toggle-es
+      // regression class the R1 role-set flip ratchet exists to catch.
+      valueShape: 'reference',
+      // en only. The other 23 languages render the recipient unmarked, so a
+      // marker there would never match their corpus rows; where the marker-less
+      // slot proves inert they stay uncaptured and the pattern lands in the
+      // baseline's `roleLossyPatterns` as named R1 burn-down tail. A language
+      // gets a real particle here ONLY if the empty slot perturbs its other
+      // parses (toggle's ja 間 / ko 동안 case).
+      markerOverride: { en: 'for' },
     },
   ],
 };

--- a/packages/semantic/src/parser/confidence-model.ts
+++ b/packages/semantic/src/parser/confidence-model.ts
@@ -186,7 +186,8 @@ export class DefaultConfidenceModel implements ConfidenceModel {
     // .panel`, handing the same-priority `toggle-es-full` (0.82, destination
     // marker mismatch) the win and silently defaulting the destination to
     // `me` — the es/pl/vi aria regression the R1 role-set flip ratchet exists
-    // to catch.
+    // to catch. take's `recipient` (valueShape 'reference') rides the same
+    // lever for the same reason: its slot is marker-less in 23 languages.
     const schemaRoles = (commandSchemas as Record<string, CommandSchema | undefined>)[
       pattern.command
     ]?.roles;

--- a/packages/semantic/src/types/grammar-types.ts
+++ b/packages/semantic/src/types/grammar-types.ts
@@ -70,6 +70,9 @@ export type SemanticRole =
   //          Used by `set @attr to V on <scope>` where destination is the attribute
   //          and scope is the element set (`on .tab` / `on me`). See setSchema.
   | 'goal' // Target value/state (to 'red', to 100)
+  | 'recipient' // Who receives what the action transfers — `take .active from .tab for me`.
+  //              Distinct from destination: take's patient moves OFF the source and ONTO
+  //              the recipient, so both ends are named. See takeSchema.
   | 'event' // Trigger (click, input, keydown)
   | 'condition' // Boolean expression (if x > 5)
   // Quantitative roles

--- a/packages/semantic/test/take-recipient.test.ts
+++ b/packages/semantic/test/take-recipient.test.ts
@@ -1,0 +1,245 @@
+/**
+ * `take <class> from <source> for <recipient>` — the recipient role.
+ *
+ * `takeSchema` modelled patient + source only, so the semantic parser matched
+ * `take .active from .tab-button for me` at confidence 1.0 and left `for me`
+ * UNCONSUMED. The corpus row `take-class-from-siblings` is exactly that
+ * surface, which made this the documented en-reference blind spot live on a
+ * real row: the English reference parse itself dropped the recipient, so every
+ * language matched the dropped reference and R0/R1/R3 all scored a perfect
+ * 1.0. Only the `unconsumed-input` diagnostic could see it. English execution
+ * was never affected — `take` is on the core parser's skipSemanticParsing list
+ * — but every consumer of the semantic parse alone (multilingual bundles, the
+ * bridge, translate()) silently lost the recipient in all 24 languages.
+ *
+ * Two constraints shape the role, and both are pinned below:
+ *
+ * 1. `valueShape: 'reference'` — the second shape-anchor kind (toggle's
+ *    duration introduced 'time'). 23 of the 24 stored corpus surfaces carry
+ *    the recipient as a BARE trailing pronoun, so the slot is marker-less
+ *    almost everywhere; without the anchor an uncaptured slot weighs into
+ *    `scoreRoleCoverage`'s denominator and drops plain
+ *    `take .active from .tab-button` from 1.0 to ~0.69 — the toggle-es
+ *    regression class.
+ * 2. `expectedTypes: ['reference']` — references only. A selector-typed slot
+ *    would swallow the second selector of `take .active from .a .b`.
+ *
+ * `source` still has NO default: bare `take .active` means "take from every
+ * element currently holding it", not "take from me" (#859). Recipient has no
+ * default either — the runtime already defaults it to `me`, and a schema
+ * default would emit an explicit `for me` on every take.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parse, parseSemantic } from '../src/index';
+import { buildAST } from '../src/ast-builder/index';
+import { getSchema } from '../src/generators/command-schemas';
+import type { CommandSemanticNode } from '../src/types';
+
+function walkCommands(node: unknown): Array<{ action: string; roles: Map<string, unknown> }> {
+  const out: Array<{ action: string; roles: Map<string, unknown> }> = [];
+  const walk = (n: unknown): void => {
+    if (!n || typeof n !== 'object') return;
+    const rec = n as Record<string, any>;
+    if (rec.kind === 'command') out.push(rec as never);
+    for (const k of ['body', 'statements', 'thenBranch', 'elseBranch']) {
+      if (Array.isArray(rec[k])) rec[k].forEach(walk);
+    }
+  };
+  walk(node);
+  return out;
+}
+
+function takeNode(source: string, lang: string): CommandSemanticNode {
+  const node = parse(source, lang);
+  expect(node, `'${source}' (${lang}) did not parse`).not.toBeNull();
+  const takes = walkCommands(node).filter(c => c.action === 'take');
+  expect(takes.length, `'${source}' (${lang}) has no take command`).toBeGreaterThan(0);
+  return takes[0] as unknown as CommandSemanticNode;
+}
+
+const roleValue = (n: CommandSemanticNode, role: string): string | undefined => {
+  const v = n.roles.get(role as never) as { value?: unknown; raw?: string } | undefined;
+  return v === undefined ? undefined : String(v.value ?? v.raw);
+};
+
+function unconsumedSpans(code: string, language: string): string[] {
+  const node = parse(code, language);
+  return (node?.diagnostics ?? []).filter(d => d.code === 'unconsumed-input').map(d => d.message);
+}
+
+describe('take declares a shape-anchored recipient role', () => {
+  const schema = getSchema('take');
+
+  it('is a real schema role wired to the `for` modifier the runtime reads', () => {
+    const recipient = schema?.roles.find(r => r.role === 'recipient');
+    expect(recipient, 'takeSchema must declare recipient').toBeDefined();
+    expect(recipient?.required, 'plain `take .active` must keep parsing').toBe(false);
+    expect(recipient?.valueShape, 'the marker-less slot is only safe shape-anchored').toBe(
+      'reference'
+    );
+    expect(
+      recipient?.expectedTypes,
+      'references only — a selector slot swallows `take .active from .a .b`'
+    ).toEqual(['reference']);
+    // The AST contract key core's TakeCommand.parseInput reads (modifiers.for).
+    expect(schema?.ast?.modifiers?.['for']).toBe('recipient');
+  });
+
+  it('keeps both transfer ends default-free', () => {
+    // #859: a `me` default on source parsed bare `take .active` as "take from
+    // me", which the runtime executed as a near-no-op. Recipient stays
+    // default-free for the mirror reason — the runtime supplies `me` itself.
+    const roles = schema?.roles ?? [];
+    expect(roles.find(r => r.role === 'source')?.default).toBeUndefined();
+    expect(roles.find(r => r.role === 'recipient')?.default).toBeUndefined();
+  });
+});
+
+describe('the English reference no longer drops `for me`', () => {
+  it('captures the recipient on the corpus surface', () => {
+    const node = takeNode('take .active from .tab-button for me', 'en');
+    expect(roleValue(node, 'patient')).toBe('.active');
+    expect(roleValue(node, 'source')).toBe('.tab-button');
+    expect(roleValue(node, 'recipient')).toBe('me');
+  });
+
+  it('leaves nothing unconsumed — the only signal that ever saw this bug', () => {
+    expect(unconsumedSpans('take .active from .tab-button for me', 'en')).toEqual([]);
+  });
+
+  it('captures it inside the event handler the corpus row actually stores', () => {
+    const node = parse('on click take .active from .tab-button for me', 'en');
+    const commands = walkCommands(node);
+    expect(
+      commands.map(c => c.action),
+      'an unconsumed `for` tail used to become a phantom for-LOOP command'
+    ).toEqual(['take']);
+    expect(roleValue(commands[0] as never, 'recipient')).toBe('me');
+    expect(unconsumedSpans('on click take .active from .tab-button for me', 'en')).toEqual([]);
+  });
+
+  it('reaches the runtime as `modifiers.for`, beside the existing `modifiers.from`', () => {
+    // TakeCommand.parseInput reads modifiers.from (source) and modifiers.for
+    // (recipient); both have been read since #859, but the semantic path could
+    // never produce the second one.
+    const node = parse('take .active from .tab-button for me', 'en') as CommandSemanticNode;
+    const ast = buildAST(node).ast as unknown as Record<string, any>;
+    expect(ast.modifiers?.from).toMatchObject({ value: '.tab-button' });
+    // A reference lands as the contextReference node the evaluator resolves —
+    // `evaluator.evaluate(raw.modifiers.for)` is what TakeCommand calls.
+    expect(ast.modifiers?.for).toMatchObject({ type: 'contextReference', contextType: 'me' });
+  });
+});
+
+describe('the reference anchor: what the slot refuses', () => {
+  it('never swallows a trailing selector into the recipient', () => {
+    // The reason expectedTypes is ['reference'] and not ['selector','reference'].
+    const node = takeNode('take .active from .tab-button .other', 'en');
+    expect(node.roles.has('recipient' as never)).toBe(false);
+    expect(roleValue(node, 'source')).toBe('.tab-button');
+  });
+
+  it('keeps a marked reference on the source side', () => {
+    const node = takeNode('take .active from me', 'en');
+    expect(roleValue(node, 'source')).toBe('me');
+    expect(node.roles.has('recipient' as never)).toBe(false);
+  });
+
+  it('parses the recipient without a source (the all-current-holders form)', () => {
+    const node = takeNode('take .active for me', 'en');
+    expect(roleValue(node, 'recipient')).toBe('me');
+    expect(node.roles.has('source' as never), 'absent source is the runtime signal').toBe(false);
+  });
+
+  it('costs the recipient-less forms no confidence — the valueShape lever', () => {
+    // MEASURED under mutation, not assumed: deleting `valueShape` from the
+    // role drops both of these from 1.0 to 0.6923 — below the 0.7 threshold at
+    // which callers adopt the semantic parse, and the same 1.0 → 0.69 number
+    // toggle's duration produced. `parseSemantic` (not `parse`) is what
+    // reports the score; asserting via `parse(...).confidence` reads
+    // `undefined` and passes vacuously.
+    for (const src of ['take .active from .tab-button', 'take .active from #parent']) {
+      const result = parseSemantic(src, 'en');
+      expect(result.node, src).not.toBeNull();
+      expect(result.confidence, src).toBe(1);
+      expect(walkCommands(result.node)[0]?.roles.has('recipient'), src).toBe(false);
+    }
+  });
+});
+
+/**
+ * The `take-class-from-siblings` translations, verbatim from a freshly
+ * `populate`d patterns.db — the exact strings the multilingual gate scores.
+ * Every one renders the recipient as a BARE trailing pronoun; only English
+ * marks it (`for`).
+ *
+ * The split below is MEASURED, not chosen: a whole-corpus probe (3960 rows,
+ * every pattern × every language, pre vs post) showed 14 languages capture the
+ * pronoun into the marker-less slot and 10 leave it uncaptured, with zero
+ * diffs anywhere else in the corpus. The 10 are the named R1 burn-down tail —
+ * they appear in the baseline's `roleLossyPatterns` for this pattern. Moving a
+ * language from DEFERRED to CAPTURED is the follow-up work; moving one the
+ * other way is a regression.
+ */
+const CAPTURED: Array<[string, string]> = [
+  ['en', 'on click take .active from .tab-button for me'],
+  ['ar', 'خذ .active من .tab-button عند نقر أنا'],
+  ['de', 'bei klick nehmen .active von .tab-button ich'],
+  ['es', 'en clic tomar .active de .tab-button yo'],
+  ['fr', 'sur clic prendre .active de .tab-button moi'],
+  ['he', 'ב לחיצה קח את .active מ .tab-button אני'],
+  ['id', 'pada klik ambil .active dari .tab-button saya'],
+  ['ms', 'apabila click ambil .active dari .tab-button saya'],
+  ['pl', 'gdy kliknięcie weź .active z .tab-button ja'],
+  ['pt', 'em clique pegar .active de .tab-button eu'],
+  ['sw', 'kwenye bonyeza chukua .active kutoka .tab-button mimi'],
+  ['th', 'เมื่อ คลิก รับ .active จาก .tab-button ฉัน'],
+  ['tl', 'kumuha .active mula_sa .tab-button kapag click ako'],
+  ['zh', '当 点击 时 拿取 把 .active 从 .tab-button 我'],
+];
+
+const DEFERRED: Array<[string, string]> = [
+  ['bn', '.active কে ক্লিক এ নিন .tab-button থেকে আমি'],
+  ['hi', '.active को क्लिक पर लें .tab-button से मैं'],
+  ['it', 'su clic prendere .active da .tab-button io'],
+  ['ja', '.active を クリック で 取る .tab-button から 私'],
+  ['ko', '.active 를 클릭 할 때 가져오다 .tab-button 에서 나'],
+  ['qu', '.active ta .tab-button manta ñitiy pi hapiy noqa'],
+  ['ru', 'при клик взять .active из .tab-button я'],
+  ['tr', '.active i tıklama de tut .tab-button den ben'],
+  ['uk', 'при клік взяти .active з .tab-button я'],
+  ['vi', 'khi nhấp lấy .active từ .tab-button tôi'],
+];
+
+describe('the corpus row, in the 14 languages that capture the recipient', () => {
+  it.each(CAPTURED)('%s binds recipient=me on a single take', (lang, source) => {
+    const commands = walkCommands(parse(source, lang));
+    expect(
+      commands.map(c => c.action),
+      `${lang}: "${source}" — an unconsumed tail became a phantom command`
+    ).toEqual(['take']);
+    const node = commands[0] as unknown as CommandSemanticNode;
+    expect(roleValue(node, 'patient'), `${lang}: patient`).toBe('.active');
+    expect(roleValue(node, 'source'), `${lang}: source`).toBe('.tab-button');
+    expect(roleValue(node, 'recipient'), `${lang}: recipient`).toBe('me');
+  });
+});
+
+describe('the corpus row, in the 10 languages still deferred (R1 burn-down tail)', () => {
+  /**
+   * These pin the CURRENT measured state, not a desired one. Each still parses
+   * the take with both other roles intact — the slot's presence perturbs
+   * nothing (that is what "passive defer" means and why no per-language marker
+   * particle was added). A language starting to capture here is progress:
+   * move it up to CAPTURED and regenerate the baseline in the same change.
+   */
+  it.each(DEFERRED)('%s parses patient + source, recipient uncaptured', (lang, source) => {
+    const commands = walkCommands(parse(source, lang));
+    expect(commands.map(c => c.action), `${lang}: "${source}"`).toEqual(['take']);
+    const node = commands[0] as unknown as CommandSemanticNode;
+    expect(roleValue(node, 'patient'), `${lang}: patient`).toBe('.active');
+    expect(roleValue(node, 'source'), `${lang}: source`).toBe('.tab-button');
+    expect(node.roles.has('recipient' as never), `${lang}: recipient`).toBe(false);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-07-31T17:24:38.032Z",
-  "commit": "5b484353",
+  "timestamp": "2026-08-01T01:36:10.542Z",
+  "commit": "cb752d5e",
   "languages": {
     "ar": {
       "parseSuccess": 155,
@@ -19,7 +19,7 @@
       "roleLossyPatterns": [
         "pick-text-range"
       ],
-      "bundleSize": 557258,
+      "bundleSize": 557470,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -651,16 +651,17 @@
       "avgFidelity": 1,
       "avgPrecision": 0.9978494623655915,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9987012987012988,
+      "avgRoleFidelity": 0.9974025974025975,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [
-        "pick-text-range"
+        "pick-text-range",
+        "take-class-from-siblings"
       ],
-      "bundleSize": 557258,
+      "bundleSize": 557470,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1302,7 +1303,7 @@
         "last-in-collection",
         "pick-text-range"
       ],
-      "bundleSize": 557258,
+      "bundleSize": 557470,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1931,7 +1932,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 557258,
+      "bundleSize": 557470,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2572,7 +2573,7 @@
       "roleLossyPatterns": [
         "pick-text-range"
       ],
-      "bundleSize": 557258,
+      "bundleSize": 557470,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3214,7 +3215,7 @@
         "last-in-collection",
         "pick-text-range"
       ],
-      "bundleSize": 557258,
+      "bundleSize": 557470,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3856,7 +3857,7 @@
         "pick-text-range",
         "set-attribute"
       ],
-      "bundleSize": 557258,
+      "bundleSize": 557470,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4488,16 +4489,17 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9987012987012988,
+      "avgRoleFidelity": 0.9974025974025975,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [
-        "pick-text-range"
+        "pick-text-range",
+        "take-class-from-siblings"
       ],
-      "bundleSize": 557258,
+      "bundleSize": 557470,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5141,7 +5143,7 @@
         "fetch-json",
         "pick-text-range"
       ],
-      "bundleSize": 557258,
+      "bundleSize": 557470,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5773,16 +5775,17 @@
       "avgFidelity": 1,
       "avgPrecision": 0.9978494623655915,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9987012987012988,
+      "avgRoleFidelity": 0.9974025974025975,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [
-        "pick-text-range"
+        "pick-text-range",
+        "take-class-from-siblings"
       ],
-      "bundleSize": 557258,
+      "bundleSize": 557470,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6414,16 +6417,17 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9987012987012988,
+      "avgRoleFidelity": 0.9974025974025975,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [
-        "pick-text-range"
+        "pick-text-range",
+        "take-class-from-siblings"
       ],
-      "bundleSize": 557258,
+      "bundleSize": 557470,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7055,7 +7059,7 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9954545454545455,
+      "avgRoleFidelity": 0.9941558441558443,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
@@ -7063,10 +7067,11 @@
       "lossyPasses": [],
       "roleLossyPatterns": [
         "pick-text-range",
+        "take-class-from-siblings",
         "when-multiple-changes",
         "when-value-changes"
       ],
-      "bundleSize": 557258,
+      "bundleSize": 557470,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7709,7 +7714,7 @@
         "last-in-collection",
         "pick-text-range"
       ],
-      "bundleSize": 557258,
+      "bundleSize": 557470,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8351,7 +8356,7 @@
         "pick-text-range",
         "unless-condition"
       ],
-      "bundleSize": 557258,
+      "bundleSize": 557470,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8992,7 +8997,7 @@
       "roleLossyPatterns": [
         "pick-text-range"
       ],
-      "bundleSize": 557258,
+      "bundleSize": 557470,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9624,7 +9629,7 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9961502782931355,
+      "avgRoleFidelity": 0.9948515769944343,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
@@ -9633,9 +9638,10 @@
       "roleLossyPatterns": [
         "announce-screen-reader",
         "on-custom-event-receive",
-        "pick-text-range"
+        "pick-text-range",
+        "take-class-from-siblings"
       ],
-      "bundleSize": 557258,
+      "bundleSize": 557470,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10267,16 +10273,17 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9987012987012988,
+      "avgRoleFidelity": 0.9974025974025975,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [
-        "pick-text-range"
+        "pick-text-range",
+        "take-class-from-siblings"
       ],
-      "bundleSize": 557258,
+      "bundleSize": 557470,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10917,7 +10924,7 @@
       "roleLossyPatterns": [
         "pick-text-range"
       ],
-      "bundleSize": 557258,
+      "bundleSize": 557470,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11560,7 +11567,7 @@
         "pick-text-range",
         "toggle-aria-expanded"
       ],
-      "bundleSize": 557258,
+      "bundleSize": 557470,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12201,7 +12208,7 @@
       "roleLossyPatterns": [
         "pick-text-range"
       ],
-      "bundleSize": 557258,
+      "bundleSize": 557470,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12833,16 +12840,17 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9987012987012988,
+      "avgRoleFidelity": 0.9974025974025975,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [
-        "pick-text-range"
+        "pick-text-range",
+        "take-class-from-siblings"
       ],
-      "bundleSize": 557258,
+      "bundleSize": 557470,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13474,16 +13482,17 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9987012987012988,
+      "avgRoleFidelity": 0.9974025974025975,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [
-        "pick-text-range"
+        "pick-text-range",
+        "take-class-from-siblings"
       ],
-      "bundleSize": 557258,
+      "bundleSize": 557470,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14115,7 +14124,7 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9952380952380955,
+      "avgRoleFidelity": 0.9939393939393941,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
@@ -14124,9 +14133,10 @@
       "roleLossyPatterns": [
         "its-value-possessive-dot",
         "last-in-collection",
-        "pick-text-range"
+        "pick-text-range",
+        "take-class-from-siblings"
       ],
-      "bundleSize": 557258,
+      "bundleSize": 557470,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14769,7 +14779,7 @@
         "repeat-forever",
         "repeat-until-event"
       ],
-      "bundleSize": 557258,
+      "bundleSize": 557470,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15396,7 +15406,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 557258,
+      "size": 557470,
       "languages": [
         "en",
         "es",


### PR DESCRIPTION
## The defect

`takeSchema` modelled `patient` + `source` only, so the semantic parser matched
`take .active from .tab-button for me` at **confidence 1.0 while leaving `for me`
unconsumed**. The corpus row `take-class-from-siblings` is exactly that surface, which
means the **en reference parse itself dropped the recipient** — every language matched
the dropped reference and R0/R1/R3 all scored a perfect 1.0. The documented
en-reference blind spot, live on a real corpus row; only the `unconsumed-input`
diagnostic could see it. English execution was never affected (`take` is on
`skipSemanticParsing`), but every consumer of the semantic parse alone — multilingual
bundles, the bridge, `translate()` — lost the recipient in all 24 languages.

Filed as handoff item #3 / MULTILINGUAL_NEXT_STEPS.md.

## The fix

A `recipient` role on `takeSchema`: `markerOverride: { en: 'for' }`,
`expectedTypes: ['reference']`, `valueShape: 'reference'`, wired to
`ast.modifiers.for` — which core's `TakeCommand.parseInput` has read since #859, so
**no runtime change was needed**. `take` STAYS on `skipSemanticParsing`: upstream also
accepts element-EXPRESSION recipients, which the reference-typed slot deliberately
refuses.

### Two premises of the filing were wrong, and measuring is why

The brief called for "per-language markers" and "i18n transformer rendering". Neither
happened:

1. **Per-language markers are not possible from the stored surfaces.** All 23 non-en
   corpus rows render the recipient as a **bare trailing pronoun** (`… von .tab-button
   ich`, `… から 私`, `… 从 .tab-button 我`) because i18n suppresses the marker for
   pronoun-valued `for` phrases. A marker would match nothing. Read the STORED
   patterns.db rows, not `translate()` — the retracted toggle-for marker table is the
   precedent for that trap.
2. **i18n rendering is deliberately out of scope.** It would rewrite all 23 stored
   surfaces and fan out into grammar tests, V2/V4 vocab, R4, and every other
   pronoun-carrying pattern. Per-language opt-in follow-up; the i18n union addition here
   is its only (behavior-free) prerequisite.

## What was measured

A **whole-corpus probe** — 3960 rows, every pattern × every language, parsed pre- and
post-change and diffed:

- **14 languages capture** the marker-less trailing pronoun: en ar de es fr he id ms pl pt sw th tl zh
- **10 do not**: bn hi it ja ko qu ru tr uk vi
- **Zero diffs anywhere else in the corpus.**

The 10 are *passive* defers — the empty slot perturbs nothing, so no inert particle was
needed (toggle's ja `間` / ko `동안` case did not recur). They land in the baseline's
`roleLossyPatterns` as the named R1 burn-down tail, worth 0.0013 of avgRoleFidelity
each. **That is the entire baseline diff** — no parse-rate change, no other metric moved.
Both lists are pinned in the test file, so a language starting to capture is a visible
failure rather than silent drift.

## `valueShape` gains a second kind

`'reference'` (closed-class context references) joins `'time'`. It is load-bearing,
**measured under mutation**: deleting it drops plain `take .active from .tab-button`
from 1.0 to **0.6923** — below the 0.7 adoption threshold, the same 1.0 → 0.69 number
toggle's duration produced.

Worth flagging for reviewers: the first version of that test asserted through
`parse(...).confidence`, which is `undefined`, so it **passed vacuously under the
mutation**. It now goes through `parseSemantic`. Both new gate rows were mutation-verified
behaviorally, not just by schema pin.

## Invariant preserved

`source` keeps **no** `default: me` (#859 — bare `take .active` means "take from all
current holders"), and `recipient` gets none either: the runtime supplies `me` itself, and
a schema default would emit an explicit `for me` on every take.

## Gates

semantic 7322 · core 7916 · i18n 949 · hyperscript-adapter 209 · mcp-server 428 ·
testing-framework 280 · vocab validate clean · all six generated-artifact sync checks ·
`multilingual --regression` green against the regenerated baseline · lint + typechecks clean.

`syntax-table.ts` regenerated (`take` gains `['recipient','for']`) with a new hand-assert
in `derive-syntax.test.ts`; committed with `git add -f` + `--no-verify` per the
tracked-but-gitignored trap. `patterns.db` deliberately not committed.

**Noted, not fixed:** `vocab validate` reports `V2|en|duration:for` as a STALE waiver.
Verified pre-existing — it went stale in #858 and is advisory-only (exit 0). Left for a
separate cleanup rather than folding an unrelated config change in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)