### PR TITLE
chore(ci): guard the four remaining hand-maintained package lists — three had drifted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -594,9 +594,24 @@ jobs:
           # (fixed in the 2026-07-20 pre-release audit). pipefail makes the
           # pipeline carry the validator's exit; the if-guard keeps the
           # summary parsing below reachable on failure.
+          #
+          # This list is GUARDED by scripts/check-ci-job-lists.cjs: every
+          # published package that declares an entry point and is built by the
+          # `build` job must appear. It used to name eight effective packages
+          # of the thirty that qualify, so twenty-two published packages could
+          # ship a dangling "exports" path with nothing to catch it — and a
+          # ninth argument, `aot-compiler`, was PRIVATE, which the validator
+          # skips outright, so it had always been a no-op.
           set -o pipefail
           status=0
-          if ! node scripts/validate-exports.mjs core semantic i18n vite-plugin mcp-server patterns-reference aot-compiler compilation-service language-server --strict 2>&1 | tee /tmp/export-validation.log; then
+          if ! node scripts/validate-exports.mjs \
+            behaviors compilation-service components core \
+            domain-bdd domain-behaviorspec domain-config domain-flow domain-jsx \
+            domain-learn domain-llm domain-sql domain-todo domain-voice \
+            framework htmx-adapter hyperscript-adapter i18n intent intent-element \
+            language-server mcp-server patterns-reference planner reactivity \
+            realtime semantic server-bridge speech vite-plugin \
+            --strict 2>&1 | tee /tmp/export-validation.log; then
             status=1
           fi
 
@@ -672,6 +687,15 @@ jobs:
       - name: Verify CI unit-test package list
         run: node scripts/check-ci-test-list.cjs
 
+      # Cheap guard: the same question asked of the FOUR remaining hand-written
+      # package enumerations — export-validation's arguments, the typecheck
+      # lines below, the nightly coverage job (cross-checked against
+      # codecov.yml's flags), and the root `lint:domains` loop. #862 guarded
+      # the unit-test lists and named these four as the follow-up; when it was
+      # written all four had drifted except lint:domains.
+      - name: Verify CI job package lists
+        run: node scripts/check-ci-job-lists.cjs
+
       # Cheap guard: zero-dep node script that fails if package versions have
       # drifted apart (the monorepo publishes uniformly).
       - name: Validate package versions
@@ -717,6 +741,18 @@ jobs:
       - name: Lint (oxlint)
         run: npm run lint
 
+      # "all packages" is now literally true. This step named eleven of the
+      # forty-four packages that declare a `typecheck` script, so a type error
+      # in any of the other thirty-three stayed green forever — including
+      # framework, semantic's own downstream domain packages, and every
+      # non-built package (testing-framework, the two vscode extensions).
+      # The list is GUARDED by scripts/check-ci-job-lists.cjs.
+      #
+      # Cost measured 2026-08-01 before expanding: all 44 take ~27s locally vs
+      # ~9s for the 11 — tsc is cheap on packages this size, and the gap was
+      # coverage nobody was paying for. The first eleven keep their original
+      # order (biggest first, so a break in core surfaces fastest); the rest
+      # are alphabetical.
       - name: Typecheck all packages
         run: |
           npm run typecheck --prefix packages/core
@@ -730,6 +766,39 @@ jobs:
           npm run typecheck --prefix packages/compilation-service
           npm run typecheck --prefix packages/mcp-server
           npm run typecheck --prefix packages/language-server
+          npm run typecheck --prefix packages/behaviors
+          npm run typecheck --prefix packages/components
+          npm run typecheck --prefix packages/developer-tools
+          npm run typecheck --prefix packages/domain-bdd
+          npm run typecheck --prefix packages/domain-behaviorspec
+          npm run typecheck --prefix packages/domain-config
+          npm run typecheck --prefix packages/domain-flow
+          npm run typecheck --prefix packages/domain-jsx
+          npm run typecheck --prefix packages/domain-learn
+          npm run typecheck --prefix packages/domain-llm
+          npm run typecheck --prefix packages/domain-sql
+          npm run typecheck --prefix packages/domain-todo
+          npm run typecheck --prefix packages/domain-toolkit
+          npm run typecheck --prefix packages/domain-voice
+          npm run typecheck --prefix packages/framework
+          npm run typecheck --prefix packages/hyperscript-tools-i18n
+          npm run typecheck --prefix packages/intent
+          npm run typecheck --prefix packages/intent-element
+          npm run typecheck --prefix packages/intercept
+          npm run typecheck --prefix packages/language-server-hyperscript
+          npm run typecheck --prefix packages/mcp-multilingual-intent
+          npm run typecheck --prefix packages/multilingual-hyperscript
+          npm run typecheck --prefix packages/planner
+          npm run typecheck --prefix packages/playground
+          npm run typecheck --prefix packages/reactivity
+          npm run typecheck --prefix packages/realtime
+          npm run typecheck --prefix packages/server-bridge
+          npm run typecheck --prefix packages/smart-bundling
+          npm run typecheck --prefix packages/speech
+          npm run typecheck --prefix packages/testing-framework
+          npm run typecheck --prefix packages/types-browser
+          npm run typecheck --prefix packages/vscode-extension
+          npm run typecheck --prefix packages/vscode-extension-hyperscript
 
       # The main tsconfig includes only src/**, so packages/core/scripts/ was
       # typechecked by nothing — that is how the doc generators kept importing

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -26,3 +26,12 @@ fi
 if git diff --cached --name-only | grep -qE '^(\.github/workflows/ci\.yml|packages/core/scripts/build-browser-bundles\.mjs)$'; then
   node scripts/check-bundle-shards.cjs || exit 1
 fi
+
+# Verify the four remaining hand-written package enumerations still match the
+# workspace: export-validation's arguments, lint-typecheck's typecheck lines,
+# the nightly coverage job (vs codecov.yml's flags), and the root lint:domains
+# loop. Fires on the four files that can drift them — note the ROOT
+# package.json is in scope here, unlike the guards above.
+if git diff --cached --name-only | grep -qE '^(packages/[^/]+/package\.json|package\.json|codecov\.yml|\.github/workflows/ci\.yml)$'; then
+  node scripts/check-ci-job-lists.cjs || exit 1
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,24 @@ When you add a new internal-dep relationship between workspace packages, add the
 
 [`npm run check:test-list`](scripts/check-test-check-list.cjs) now fails on either. It's a zero-dep node script, run in CI's `lint-typecheck` job and from the pre-commit hook when a workspace `package.json` or the gate script is staged. Deliberate exclusions go in its `INTENTIONALLY_UNGATED` map, with a reason.
 
+##### The six hand-maintained package lists, and what guards each
+
+CI addresses packages by name in six places, all hand-written. **Every one is now guarded** — the last four by [`npm run check:ci-job-lists`](scripts/check-ci-job-lists.cjs), and all six by zero-dep node scripts wired into `lint-typecheck` and the pre-commit hook.
+
+| List                                       | Guard                | Predicate ("must be listed iff…")                                             |
+| ------------------------------------------ | -------------------- | ----------------------------------------------------------------------------- |
+| `build` job step ORDER                     | `check:ci-order`     | a runtime dep is built before its consumer                                    |
+| `unit-tests` / `unit-tests-packages` steps | `check:ci-test-list` | the package has a `test:check` script                                         |
+| `scripts/test-check-all.sh`                | `check:test-list`    | same predicate, local gate                                                    |
+| `export-validation` args                   | `check:ci-job-lists` | published **and** declares an entry point **and** is built by the `build` job |
+| `lint-typecheck` typecheck lines           | `check:ci-job-lists` | the package has a `typecheck` script                                          |
+| nightly `coverage` job                     | `check:ci-job-lists` | its flag is declared in `codecov.yml` (both directions)                       |
+| root `lint:domains` loop                   | `check:ci-job-lists` | a `packages/domain-*` owning a `lint.test.ts`                                 |
+
+When the last four were guarded (2026-08-01), three had drifted: export-validation checked **8** of the 30 packages that qualify (its 9th argument, `aot-compiler`, is private, which the validator skips outright — an argument that had never done anything); the "Typecheck all packages" step ran **11** of 44; and the coverage job uploaded a `language-server` flag `codecov.yml` never declared. `lint:domains` was already correct at 9/9. Deliberate omissions go in the script's per-list `INTENTIONAL_OMISSIONS` maps, with a reason; all three start empty.
+
+**Adding a package to the typecheck list needs it to typecheck on a clean checkout**, not just in your tree. `packages/behaviors` was the trap: its `src/generated/` is gitignored, so `tsc` there fails on a fresh clone — it needs a `pretypecheck` hook, the same way it already had `prebuild`/`pretest`. This is the same "working tree ≠ clean checkout" class that cost #862/#863 two CI round-trips.
+
 > **Neither hook fires for direct `npx vitest` / `npx tsx` invocations.** That's
 > how the qu "unreproducible baseline" incident happened (roadmap §7g): a sweep
 > executed a stale `dist/` and scored code that differed from the checkout. The

--- a/codecov.yml
+++ b/codecov.yml
@@ -33,6 +33,16 @@ flags:
     paths:
       - packages/i18n/src/**
     carryforward: true
+  # The nightly coverage job has uploaded a `language-server` flag since the
+  # step was added, but the flag was never declared here — so it got no
+  # `paths:` and no `carryforward`, and behaved differently from the three
+  # above. scripts/check-ci-job-lists.cjs now fails on either direction of the
+  # mismatch (an undeclared uploaded flag, or a declared flag nothing uploads —
+  # which `carryforward: true` would make serve its last report forever).
+  language-server:
+    paths:
+      - packages/language-server/src/**
+    carryforward: true
 
 comment:
   layout: 'header, diff, flags, components'

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "check:test-list:test": "node --test scripts/check-test-check-list.test.cjs",
     "check:ci-test-list": "node scripts/check-ci-test-list.cjs",
     "check:ci-test-list:test": "node --test scripts/check-ci-test-list.test.cjs",
+    "check:ci-job-lists": "node scripts/check-ci-job-lists.cjs",
+    "check:ci-job-lists:test": "node --test scripts/check-ci-job-lists.test.cjs",
     "compatibility:monitor": "node scripts/compatibility-monitor.js",
     "compatibility:improve": "node scripts/improvement-workflow.js",
     "compatibility:cycle": "npm run compatibility:monitor && npm run compatibility:improve",

--- a/packages/behaviors/package.json
+++ b/packages/behaviors/package.json
@@ -106,6 +106,7 @@
     "prebuild": "npm run generate",
     "build": "tsup",
     "build:watch": "tsup --watch",
+    "pretypecheck": "npm run generate",
     "typecheck": "tsc --noEmit",
     "pretest": "npm run generate",
     "test": "vitest run",

--- a/scripts/check-ci-job-lists.cjs
+++ b/scripts/check-ci-job-lists.cjs
@@ -1,0 +1,854 @@
+#!/usr/bin/env node
+/**
+ * check-ci-job-lists — the four remaining hand-maintained package enumerations
+ *
+ * #862 guarded ci.yml's unit-test enumeration (scripts/check-ci-test-list.cjs)
+ * and noted that FOUR more hand-written package lists were left unguarded. This
+ * is that follow-up. Each list answers a different question, so each gets its
+ * own predicate — but the failure shape is identical in all four: a package
+ * silently drops out of (or never joins) a gate, and the gate stays green.
+ *
+ *   1. export-validation  the positional args of `scripts/validate-exports.mjs`
+ *   2. typecheck          the `npm run typecheck --prefix …` lines in lint-typecheck
+ *   3. coverage           the nightly job's packages, cross-checked with codecov.yml
+ *   4. lint:domains       the nine-domain shell loop in the ROOT package.json
+ *
+ * Measured drift when this was written (2026-08-01), all four in one run:
+ *
+ *   • export-validation validated 8 of the 30 packages that qualify, and its
+ *     9th arg (`aot-compiler`) is PRIVATE — validate-exports.mjs prints
+ *     `[SKIP] … Private package` for it, so that arg had always been a no-op.
+ *   • typecheck ran 11 of the 44 packages that declare a `typecheck` script.
+ *     All 44 pass, and all 44 together take ~27s locally vs ~9s for the 11 —
+ *     the gap was cost-free coverage nobody had claimed.
+ *   • the coverage job uploads a `language-server` flag that codecov.yml never
+ *     declares, so it gets neither `paths:` nor `carryforward: true`.
+ *   • lint:domains was already correct at 9/9 — that class is pure prevention.
+ *
+ * Why one script and not four: the four lists are the same question asked of
+ * two files, they share every parse primitive, and the pre-commit hook pays one
+ * node boot instead of four. Each class is independently testable and reports
+ * independently, so a failure still names exactly one list.
+ *
+ * `sliceJob` is imported from the sibling rather than copied. It is a parse
+ * PRIMITIVE (cut one job's body out of the workflow), not a parse TARGET — the
+ * decoupling the sibling's header argues for is about not letting one guard's
+ * notion of "which packages count" leak into another's, which still holds here:
+ * all four predicates below are derived from disk, independently.
+ *
+ * Zero runtime deps — node built-ins only, so it stays cheap enough for both
+ * the pre-commit hook and the CI lint-typecheck step.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { sliceJob } = require('./check-ci-test-list.cjs');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const PACKAGES_DIR = path.join(REPO_ROOT, 'packages');
+const CI_WORKFLOW = path.join(REPO_ROOT, '.github', 'workflows', 'ci.yml');
+const CODECOV_CONFIG = path.join(REPO_ROOT, 'codecov.yml');
+const ROOT_PACKAGE_JSON = path.join(REPO_ROOT, 'package.json');
+
+/**
+ * Fields validate-exports.mjs actually checks. A package declaring ANY of them
+ * has something the validator can find missing; a package declaring none is
+ * outside its jurisdiction entirely.
+ */
+const ENTRY_POINT_FIELDS = ['main', 'module', 'types', 'browser', 'exports'];
+
+/**
+ * Deliberate omissions, per list. Keep these empty if you can — an entry means
+ * a real package a real gate will never see. Each MUST carry a reason.
+ *
+ * `coverage` has no map on purpose: it is a bidirectional correspondence
+ * between two files that must simply agree, and "this flag is declared but
+ * never uploaded" has no benign form — codecov.yml's `carryforward: true`
+ * makes it serve the last report it ever received, forever.
+ */
+const INTENTIONAL_OMISSIONS = {
+  'export-validation': new Map([
+    // e.g. ['some-package', 'ships prebuilt; dist is not produced in CI'],
+  ]),
+  typecheck: new Map([
+    // e.g. ['some-package', 'needs a codegen step CI does not run'],
+  ]),
+  'lint:domains': new Map([
+    // e.g. ['domain-x', 'lint suite is quarantined pending the vocab arc'],
+  ]),
+};
+
+// ---------------------------------------------------------------------------
+// Loaders
+// ---------------------------------------------------------------------------
+
+/** Does packages/<dir>/src contain a `lint.test.ts` anywhere? */
+function hasLintSuite(dir) {
+  const srcDir = path.join(PACKAGES_DIR, dir, 'src');
+  const stack = [srcDir];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      continue; // no src/, or unreadable — not a lint-suite owner
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+        stack.push(path.join(current, entry.name));
+      } else if (entry.name === 'lint.test.ts') {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Read every packages/*\/package.json into the facts the four predicates need.
+ * Keyed by DIRECTORY, because every list under guard addresses packages by
+ * directory (`--prefix packages/<dir>`, `packages/<dir>/coverage/lcov.info`).
+ */
+function loadWorkspaces() {
+  const byDir = new Map();
+
+  for (const dirent of fs.readdirSync(PACKAGES_DIR, { withFileTypes: true })) {
+    if (!dirent.isDirectory()) continue;
+    const pkgPath = path.join(PACKAGES_DIR, dirent.name, 'package.json');
+    let raw;
+    try {
+      raw = fs.readFileSync(pkgPath, 'utf8');
+    } catch {
+      continue; // directory without package.json (stale build leftovers) — skip
+    }
+    let pkg;
+    try {
+      pkg = JSON.parse(raw);
+    } catch {
+      throw new Error(`check-ci-job-lists: invalid JSON in ${pkgPath}`);
+    }
+
+    const scripts = pkg.scripts || {};
+    byDir.set(dirent.name, {
+      name: pkg.name || dirent.name,
+      isPrivate: Boolean(pkg.private),
+      hasEntryPoint: ENTRY_POINT_FIELDS.some(field => pkg[field]),
+      hasTypecheck: Boolean(scripts.typecheck),
+      hasTest: Boolean(scripts.test),
+      hasLintSuite: dirent.name.startsWith('domain-') && hasLintSuite(dirent.name),
+    });
+  }
+
+  return byDir;
+}
+
+function readCi(text) {
+  if (text !== undefined) return text;
+  try {
+    return fs.readFileSync(CI_WORKFLOW, 'utf8');
+  } catch (err) {
+    throw new Error(`check-ci-job-lists: cannot read ${CI_WORKFLOW}: ${err.message}`);
+  }
+}
+
+/** Require a job to exist, with a message that says what to do if it moved. */
+function requireJob(text, jobName) {
+  const body = sliceJob(text, jobName);
+  if (body === null) {
+    throw new Error(
+      `check-ci-job-lists: no "${jobName}:" job found in .github/workflows/ci.yml. ` +
+        `If it was renamed or removed, update scripts/check-ci-job-lists.cjs — ` +
+        `otherwise this guard would silently stop checking it.`
+    );
+  }
+  return body;
+}
+
+/**
+ * Packages the `build` job builds. Not a list under guard (check-ci-build-order
+ * owns its ORDER); it is the denominator for the export-validation predicate,
+ * because a package CI never builds has no dist in the artifact and could only
+ * ever be validated against thin air.
+ */
+function loadCiBuiltPackages(text) {
+  const body = requireJob(readCi(text), 'build');
+  const built = new Set();
+  const pattern = /^[ \t]*run:[ \t]*npm run [A-Za-z0-9:_-]+ --prefix packages\/([A-Za-z0-9-]+)/gm;
+  let m;
+  while ((m = pattern.exec(body)) !== null) built.add(m[1]);
+
+  if (built.size === 0) {
+    throw new Error(
+      `check-ci-job-lists: the "build" job has no ` +
+        `\`run: npm run <script> --prefix packages/<dir>\` steps. Its step shape ` +
+        `changed — update loadCiBuiltPackages() in scripts/check-ci-job-lists.cjs.`
+    );
+  }
+  return built;
+}
+
+/**
+ * Join one shell logical line, following `\` continuations.
+ *
+ * The export-validation arg list is 30 package names; on one physical line it
+ * is unreviewable, so ci.yml wraps it. Reading only the first physical line
+ * would see four packages and report the other 26 as missing.
+ */
+function joinContinuedLine(text) {
+  let logical = '';
+  for (const line of text.split('\n')) {
+    const trimmed = line.replace(/[ \t]+$/, '');
+    if (trimmed.endsWith('\\')) {
+      logical += `${trimmed.slice(0, -1)} `;
+      continue;
+    }
+    logical += trimmed;
+    break;
+  }
+  return logical;
+}
+
+/**
+ * The positional args of `node scripts/validate-exports.mjs`.
+ *
+ * The real invocation is wrapped in an `if ! … | tee …; then` so the summary
+ * parsing below it stays reachable on failure, so we cannot anchor on start of
+ * line. Positional args run until the first `-`-prefixed token; everything past
+ * that is flags and shell (`--strict 2>&1 | tee …; then`).
+ */
+function loadExportValidationArgs(text) {
+  const body = requireJob(readCi(text), 'export-validation');
+  const INVOCATION = 'node scripts/validate-exports.mjs';
+  const idx = body.indexOf(INVOCATION);
+  if (idx === -1) {
+    throw new Error(
+      `check-ci-job-lists: the "export-validation" job does not invoke ` +
+        `\`node scripts/validate-exports.mjs\`. Either the gate was removed — in ` +
+        `which case delete this check — or its shape changed; update ` +
+        `loadExportValidationArgs() in scripts/check-ci-job-lists.cjs.`
+    );
+  }
+
+  const args = [];
+  for (const token of joinContinuedLine(body.slice(idx + INVOCATION.length))
+    .trim()
+    .split(/\s+/)) {
+    if (token === '') continue;
+    if (token.startsWith('-')) break;
+    args.push(token);
+  }
+
+  if (args.length === 0) {
+    throw new Error(
+      `check-ci-job-lists: \`validate-exports.mjs\` is invoked with no package ` +
+        `arguments. With no filter it validates EVERY package, including ones CI ` +
+        `never builds, so this is almost certainly an accident. If it is not, ` +
+        `delete the export-validation check from scripts/check-ci-job-lists.cjs.`
+    );
+  }
+  return args;
+}
+
+/**
+ * The `npm run typecheck --prefix packages/<dir>` lines of `lint-typecheck`.
+ *
+ * These live inside a `run: |` block, so they are bare commands, not `run:`
+ * steps. Requiring `typecheck` to be followed by whitespace is what keeps the
+ * separate `typecheck:scripts` step from being read as a 12th package.
+ */
+function loadTypecheckDirs(text) {
+  const body = requireJob(readCi(text), 'lint-typecheck');
+  const dirs = [];
+  const pattern = /^[ \t]*npm run typecheck[ \t]+--prefix[ \t]+packages\/([A-Za-z0-9-]+)[ \t]*$/gm;
+  let m;
+  while ((m = pattern.exec(body)) !== null) dirs.push(m[1]);
+
+  if (dirs.length === 0) {
+    throw new Error(
+      `check-ci-job-lists: the "lint-typecheck" job has no ` +
+        `\`npm run typecheck --prefix packages/<dir>\` lines. Either typechecking ` +
+        `moved (to a workspaces run, a matrix, or a script) — in which case ` +
+        `update loadTypecheckDirs() in scripts/check-ci-job-lists.cjs — or CI ` +
+        `stopped typechecking entirely.`
+    );
+  }
+  return dirs;
+}
+
+/**
+ * The nightly `coverage` job's two step families.
+ *
+ * generate: any run line naming a package AND mentioning coverage — the job
+ *   uses two spellings (`npm run test:coverage --prefix x` and
+ *   `npm test --prefix x -- --coverage`) and both are legitimate.
+ * upload:   codecov-action `with:` blocks, paired by scanning forward from each
+ *   `files: packages/<dir>/coverage/lcov.info` to its `flags:`.
+ */
+function loadCoverageSteps(text) {
+  const body = requireJob(readCi(text), 'coverage');
+
+  const generates = [];
+  const genPattern = /^[ \t]*run:[ \t]*([^\n]*--prefix[ \t]+packages\/([A-Za-z0-9-]+)[^\n]*)$/gm;
+  let m;
+  while ((m = genPattern.exec(body)) !== null) {
+    if (!/coverage/.test(m[1])) continue;
+    generates.push({ dir: m[2], command: m[1].trim() });
+  }
+
+  const uploads = [];
+  const filesPattern =
+    /^[ \t]*files:[ \t]*packages\/([A-Za-z0-9-]+)\/coverage\/lcov\.info[ \t]*$/gm;
+  while ((m = filesPattern.exec(body)) !== null) {
+    const after = body.slice(m.index + m[0].length);
+    const flagMatch = /^[ \t]*flags:[ \t]*([A-Za-z0-9_-]+)[ \t]*$/m.exec(after);
+    uploads.push({ dir: m[1], flag: flagMatch ? flagMatch[1] : null });
+  }
+
+  if (generates.length === 0 || uploads.length === 0) {
+    throw new Error(
+      `check-ci-job-lists: the "coverage" job has ${generates.length} coverage ` +
+        `run steps and ${uploads.length} Codecov upload steps; both must be ` +
+        `non-empty. Its step shape changed — update loadCoverageSteps() in ` +
+        `scripts/check-ci-job-lists.cjs.`
+    );
+  }
+  return { generates, uploads };
+}
+
+/**
+ * codecov.yml's declared flags, with the `paths:` each claims.
+ *
+ * Regex, not a YAML parser, for the same reason as the sibling guards: the
+ * shape is fixed and a parser plus its dependency would outweigh the thing it
+ * guards. The `flags:` block ends at the next column-0 key.
+ */
+function loadCodecovFlags(text) {
+  if (text === undefined) {
+    try {
+      text = fs.readFileSync(CODECOV_CONFIG, 'utf8');
+    } catch (err) {
+      throw new Error(`check-ci-job-lists: cannot read ${CODECOV_CONFIG}: ${err.message}`);
+    }
+  }
+
+  const start = /^flags:[ \t]*$/m.exec(text);
+  if (!start) {
+    throw new Error(
+      `check-ci-job-lists: codecov.yml has no top-level \`flags:\` block. Every ` +
+        `flag the coverage job uploads needs one (for \`paths:\` and ` +
+        `\`carryforward\`); if flags were abandoned, delete the coverage check ` +
+        `from scripts/check-ci-job-lists.cjs.`
+    );
+  }
+
+  const rest = text.slice(start.index + start[0].length);
+  const nextTop = /^[A-Za-z0-9_-]+:/m.exec(rest);
+  const block = nextTop ? rest.slice(0, nextTop.index) : rest;
+
+  const flags = new Map();
+  const flagPattern = /^ {2}([A-Za-z0-9_-]+):[ \t]*$/gm;
+  let m;
+  while ((m = flagPattern.exec(block)) !== null) {
+    const flagName = m[1];
+    const after = block.slice(m.index + m[0].length);
+    const end = /^ {2}[A-Za-z0-9_-]+:[ \t]*$/m.exec(after);
+    const flagBody = end ? after.slice(0, end.index) : after;
+
+    const paths = [];
+    const pathPattern = /^[ \t]*-[ \t]*(\S+)[ \t]*$/gm;
+    let p;
+    while ((p = pathPattern.exec(flagBody)) !== null) paths.push(p[1]);
+
+    flags.set(flagName, { paths, carryforward: /carryforward:[ \t]*true/.test(flagBody) });
+  }
+  return flags;
+}
+
+/** The domain suffixes of the root `lint:domains` shell loop. */
+function loadLintDomains(text) {
+  if (text === undefined) {
+    try {
+      text = fs.readFileSync(ROOT_PACKAGE_JSON, 'utf8');
+    } catch (err) {
+      throw new Error(`check-ci-job-lists: cannot read ${ROOT_PACKAGE_JSON}: ${err.message}`);
+    }
+  }
+
+  let script;
+  try {
+    script = (JSON.parse(text).scripts || {})['lint:domains'];
+  } catch {
+    throw new Error(`check-ci-job-lists: invalid JSON in ${ROOT_PACKAGE_JSON}`);
+  }
+  if (!script) {
+    throw new Error(
+      `check-ci-job-lists: the root package.json has no "lint:domains" script. ` +
+        `If it was renamed or removed, update loadLintDomains() in ` +
+        `scripts/check-ci-job-lists.cjs.`
+    );
+  }
+
+  const m = /for\s+pkg\s+in\s+([^;]+);/.exec(script);
+  if (!m || !/packages\/domain-\$pkg/.test(script)) {
+    throw new Error(
+      `check-ci-job-lists: cannot parse "lint:domains" — expected a ` +
+        `\`for pkg in <suffixes>; do … packages/domain-$pkg …\` loop, got:\n` +
+        `    ${script}\n` +
+        `  Update loadLintDomains() in scripts/check-ci-job-lists.cjs to match.`
+    );
+  }
+
+  return m[1].trim().split(/\s+/).filter(Boolean);
+}
+
+// ---------------------------------------------------------------------------
+// Checks — one function per list, each returning human-readable failures
+// ---------------------------------------------------------------------------
+
+/**
+ * Shared stale-exemption sweep: an omission entry that no longer describes
+ * reality is worse than none, because it reads as a considered decision.
+ */
+function checkStaleOmissions(listName, omissions, byDir, isEnumerated, qualifies) {
+  const failures = [];
+  for (const [dir, reason] of omissions) {
+    const pkg = byDir.get(dir);
+    if (!pkg) {
+      failures.push(
+        `INTENTIONAL_OMISSIONS["${listName}"] lists packages/${dir} ("${reason}"), but no ` +
+          `such workspace package exists. Remove the entry from ` +
+          `scripts/check-ci-job-lists.cjs.`
+      );
+      continue;
+    }
+    if (isEnumerated(dir)) {
+      failures.push(
+        `INTENTIONAL_OMISSIONS["${listName}"] lists packages/${dir} ("${reason}"), but the ` +
+          `${listName} list now includes it. Remove the entry from ` +
+          `scripts/check-ci-job-lists.cjs.`
+      );
+      continue;
+    }
+    if (!qualifies(dir, pkg)) {
+      failures.push(
+        `INTENTIONAL_OMISSIONS["${listName}"] lists packages/${dir} ("${reason}"), but ` +
+          `${pkg.name} no longer qualifies for the ${listName} list anyway, so the ` +
+          `exemption is doing nothing. Remove it from scripts/check-ci-job-lists.cjs.`
+      );
+    }
+  }
+  return failures;
+}
+
+/**
+ * (1) export-validation.
+ *
+ * Qualifies = published, declares an entry point, and is built by the `build`
+ * job. All three matter: the validator refuses private packages outright, has
+ * nothing to check without an entry-point field, and can only resolve paths
+ * against a dist the build artifact actually carries.
+ */
+function checkExportValidation(byDir, builtInCi, args, omissions) {
+  const failures = [];
+  const qualifies = (dir, pkg) =>
+    !pkg.isPrivate && pkg.hasEntryPoint && builtInCi.has(dir) && !omissions.has(dir);
+
+  const seen = new Set();
+  for (const dir of args) {
+    if (seen.has(dir)) {
+      failures.push(
+        `export-validation passes packages/${dir} to validate-exports.mjs twice. ` +
+          `Remove the duplicate argument from .github/workflows/ci.yml.`
+      );
+      continue;
+    }
+    seen.add(dir);
+
+    const pkg = byDir.get(dir);
+    if (!pkg) {
+      failures.push(
+        `export-validation passes "${dir}" to validate-exports.mjs, but no such ` +
+          `workspace package exists. The validator filters its package list by ` +
+          `name, so an unmatched argument validates NOTHING and the job still ` +
+          `passes. Remove it from .github/workflows/ci.yml.`
+      );
+      continue;
+    }
+    if (pkg.isPrivate) {
+      failures.push(
+        `export-validation passes packages/${dir} to validate-exports.mjs, but ` +
+          `${pkg.name} is private — the validator prints "[SKIP] ${dir}: Private ` +
+          `package" and checks nothing, so the argument is a silent no-op. Drop ` +
+          `the argument, or drop "private": true if the package is meant to ship.`
+      );
+      continue;
+    }
+    if (!pkg.hasEntryPoint) {
+      failures.push(
+        `export-validation passes packages/${dir} to validate-exports.mjs, but ` +
+          `${pkg.name} declares none of ${ENTRY_POINT_FIELDS.join('/')}, so there is ` +
+          `nothing to validate. Remove the argument from .github/workflows/ci.yml.`
+      );
+      continue;
+    }
+    if (!builtInCi.has(dir)) {
+      failures.push(
+        `export-validation passes packages/${dir} to validate-exports.mjs, but the ` +
+          `\`build\` job never builds it, so no dist/ reaches the job's artifact and ` +
+          `every declared export reads as missing. Either add a build step, or ` +
+          `remove the argument from .github/workflows/ci.yml.`
+      );
+    }
+  }
+
+  for (const [dir, pkg] of byDir) {
+    if (!qualifies(dir, pkg)) continue;
+    if (seen.has(dir)) continue;
+    failures.push(
+      `${pkg.name} (packages/${dir}) is published, declares an entry point, and is ` +
+        `built in CI, but is NOT passed to validate-exports.mjs — so it can ship ` +
+        `with a dangling "exports" path and no gate will notice. Add "${dir}" to ` +
+        `the argument list in the "Validate all package exports" step of ` +
+        `.github/workflows/ci.yml. If skipping is deliberate, add it to ` +
+        `INTENTIONAL_OMISSIONS["export-validation"] with a reason.`
+    );
+  }
+
+  failures.push(
+    ...checkStaleOmissions(
+      'export-validation',
+      omissions,
+      byDir,
+      dir => seen.has(dir),
+      (dir, pkg) => !pkg.isPrivate && pkg.hasEntryPoint && builtInCi.has(dir)
+    )
+  );
+
+  return failures;
+}
+
+/** (2) lint-typecheck. Qualifies = declares a `typecheck` script. Nothing else. */
+function checkTypecheck(byDir, dirs, omissions) {
+  const failures = [];
+  const seen = new Set();
+
+  for (const dir of dirs) {
+    if (seen.has(dir)) {
+      failures.push(
+        `lint-typecheck runs \`npm run typecheck --prefix packages/${dir}\` twice. ` +
+          `tsc is not free; remove the duplicate line from .github/workflows/ci.yml.`
+      );
+      continue;
+    }
+    seen.add(dir);
+
+    const pkg = byDir.get(dir);
+    if (!pkg) {
+      failures.push(
+        `lint-typecheck runs \`npm run typecheck --prefix packages/${dir}\`, but no ` +
+          `such workspace package exists — the step dies on an ENOENT and fails ` +
+          `the job. Remove the line from .github/workflows/ci.yml.`
+      );
+      continue;
+    }
+    if (!pkg.hasTypecheck) {
+      failures.push(
+        `lint-typecheck runs \`npm run typecheck --prefix packages/${dir}\`, but ` +
+          `${pkg.name} has no "typecheck" script. Add one to ` +
+          `packages/${dir}/package.json, or drop the line.`
+      );
+    }
+  }
+
+  for (const [dir, pkg] of byDir) {
+    if (!pkg.hasTypecheck) continue;
+    if (seen.has(dir)) continue;
+    if (omissions.has(dir)) continue;
+    failures.push(
+      `${pkg.name} (packages/${dir}) has a "typecheck" script that CI never runs, ` +
+        `so a type error there stays green forever. Add to the "Typecheck all ` +
+        `packages" step of .github/workflows/ci.yml:\n` +
+        `          npm run typecheck --prefix packages/${dir}\n` +
+        `    If the package needs a codegen step first, give it a "pretypecheck" ` +
+        `hook (packages/behaviors does — its src/generated/ is gitignored, so a ` +
+        `clean checkout has none). If skipping is deliberate, add it to ` +
+        `INTENTIONAL_OMISSIONS["typecheck"] with a reason.`
+    );
+  }
+
+  failures.push(
+    ...checkStaleOmissions(
+      'typecheck',
+      omissions,
+      byDir,
+      dir => seen.has(dir),
+      (dir, pkg) => pkg.hasTypecheck
+    )
+  );
+
+  return failures;
+}
+
+/**
+ * (3) coverage ⇔ codecov.yml.
+ *
+ * No "every package with coverage must be here" rule: the nightly is a
+ * reporting job, not a gate, and which packages it reports on is an editorial
+ * choice. What is NOT editorial is that the two files agree — codecov.yml's
+ * `carryforward: true` means a flag that stops being uploaded silently serves
+ * its last report forever, which reads as coverage rather than absence.
+ */
+function checkCoverage(byDir, coverage, codecovFlags) {
+  const failures = [];
+  const generatedDirs = new Set(coverage.generates.map(step => step.dir));
+  const uploadedDirs = new Set(coverage.uploads.map(step => step.dir));
+
+  for (const { dir, command } of coverage.generates) {
+    const pkg = byDir.get(dir);
+    if (!pkg) {
+      failures.push(
+        `the coverage job runs \`${command}\`, but packages/${dir} does not exist. ` +
+          `Remove the step from .github/workflows/ci.yml.`
+      );
+      continue;
+    }
+    if (!pkg.hasTest) {
+      failures.push(
+        `the coverage job generates coverage for packages/${dir}, but ${pkg.name} ` +
+          `has no "test" script to generate it from.`
+      );
+    }
+    if (!uploadedDirs.has(dir)) {
+      failures.push(
+        `the coverage job generates coverage for packages/${dir} but never uploads ` +
+          `it — the run pays for the instrumented suite and throws the report ` +
+          `away. Add a codecov-action step with ` +
+          `\`files: packages/${dir}/coverage/lcov.info\`, or drop the generate step.`
+      );
+    }
+  }
+
+  for (const { dir, flag } of coverage.uploads) {
+    if (!generatedDirs.has(dir)) {
+      failures.push(
+        `the coverage job uploads packages/${dir}/coverage/lcov.info but never ` +
+          `generates it, so the upload sends a stale or absent report. Add a ` +
+          `coverage run step for packages/${dir}, or drop the upload.`
+      );
+    }
+    if (flag === null) {
+      failures.push(
+        `the coverage job uploads packages/${dir}/coverage/lcov.info with no ` +
+          `\`flags:\` key, so its lines land in the unflagged default and cannot be ` +
+          `attributed. Add \`flags: ${dir}\`.`
+      );
+      continue;
+    }
+    if (flag !== dir) {
+      failures.push(
+        `the coverage job uploads packages/${dir}/coverage/lcov.info under flag ` +
+          `"${flag}". Flags are named after their package here, and codecov.yml ` +
+          `maps each flag to \`packages/<flag>/src/**\` — a mismatch silently ` +
+          `attributes one package's lines to another. Use \`flags: ${dir}\`.`
+      );
+      continue;
+    }
+    if (!codecovFlags.has(flag)) {
+      failures.push(
+        `the coverage job uploads flag "${flag}", which codecov.yml never declares ` +
+          `— so it gets no \`paths:\` and no \`carryforward\`, and behaves ` +
+          `differently from every declared flag. Add to codecov.yml:\n` +
+          `  ${flag}:\n` +
+          `    paths:\n` +
+          `      - packages/${dir}/src/**\n` +
+          `    carryforward: true`
+      );
+    }
+  }
+
+  for (const [flag, spec] of codecovFlags) {
+    if (!uploadedDirs.has(flag)) {
+      failures.push(
+        `codecov.yml declares flag "${flag}", but the coverage job never uploads ` +
+          `it. With \`carryforward: ${spec.carryforward}\` Codecov keeps serving the ` +
+          `last report this flag ever received, so the number looks live while ` +
+          `nothing measures it. Add the generate+upload pair to the coverage job, ` +
+          `or remove the flag from codecov.yml.`
+      );
+      continue;
+    }
+    const expected = `packages/${flag}/src/**`;
+    if (spec.paths.length > 0 && !spec.paths.includes(expected)) {
+      failures.push(
+        `codecov.yml's "${flag}" flag claims paths [${spec.paths.join(', ')}], which ` +
+          `does not include ${expected} — the flag and the package it is uploaded ` +
+          `from disagree about what it covers.`
+      );
+    }
+  }
+
+  return failures;
+}
+
+/**
+ * (4) root `lint:domains`.
+ *
+ * Qualifies = a `packages/domain-*` package that owns a `lint.test.ts`. The
+ * loop is local-only (ci.yml deliberately does not run it — the unit-test job
+ * already executes each domain's lint suite as part of its vitest run), so
+ * drift here costs a local convenience gate, not a CI one.
+ */
+function checkLintDomains(byDir, suffixes, omissions) {
+  const failures = [];
+  const seen = new Set();
+
+  for (const suffix of suffixes) {
+    const dir = `domain-${suffix}`;
+    if (seen.has(suffix)) {
+      failures.push(`the root "lint:domains" loop lists "${suffix}" twice. Remove the duplicate.`);
+      continue;
+    }
+    seen.add(suffix);
+
+    const pkg = byDir.get(dir);
+    if (!pkg) {
+      failures.push(
+        `the root "lint:domains" loop lists "${suffix}", but packages/${dir} does ` +
+          `not exist — the loop exits 1 on a healthy tree. Remove it from the ` +
+          `"lint:domains" script in package.json.`
+      );
+      continue;
+    }
+    if (!pkg.hasLintSuite) {
+      failures.push(
+        `the root "lint:domains" loop lists "${suffix}", but packages/${dir} has no ` +
+          `lint.test.ts under src/ — \`vitest --run lint\` matches no test file ` +
+          `there. Remove it from the "lint:domains" script in package.json.`
+      );
+    }
+  }
+
+  for (const [dir, pkg] of byDir) {
+    if (!pkg.hasLintSuite) continue;
+    const suffix = dir.slice('domain-'.length);
+    if (seen.has(suffix)) continue;
+    if (omissions.has(dir)) continue;
+    failures.push(
+      `${pkg.name} (packages/${dir}) owns a lint.test.ts but is not in the root ` +
+        `"lint:domains" loop, so \`npm run lint:domains\` silently skips it. Add ` +
+        `"${suffix}" to the \`for pkg in …\` list in package.json. If skipping is ` +
+        `deliberate, add "${dir}" to INTENTIONAL_OMISSIONS["lint:domains"] with a ` +
+        `reason.`
+    );
+  }
+
+  failures.push(
+    ...checkStaleOmissions(
+      'lint:domains',
+      omissions,
+      byDir,
+      dir => seen.has(dir.slice('domain-'.length)),
+      (dir, pkg) => pkg.hasLintSuite
+    )
+  );
+
+  return failures;
+}
+
+/**
+ * Run all four. Returns Map<listName, failures[]> so the reporter can group by
+ * list — four independent questions should not read as one undifferentiated
+ * wall of text.
+ */
+function check(input, omissions = INTENTIONAL_OMISSIONS) {
+  const { byDir, builtInCi, exportArgs, typecheckDirs, coverage, codecovFlags, lintDomains } =
+    input;
+
+  return new Map([
+    [
+      'export-validation',
+      checkExportValidation(
+        byDir,
+        builtInCi,
+        exportArgs,
+        omissions['export-validation'] ?? new Map()
+      ),
+    ],
+    ['typecheck', checkTypecheck(byDir, typecheckDirs, omissions.typecheck ?? new Map())],
+    ['coverage', checkCoverage(byDir, coverage, codecovFlags)],
+    ['lint:domains', checkLintDomains(byDir, lintDomains, omissions['lint:domains'] ?? new Map())],
+  ]);
+}
+
+function loadAll() {
+  const ci = readCi();
+  return {
+    byDir: loadWorkspaces(),
+    builtInCi: loadCiBuiltPackages(ci),
+    exportArgs: loadExportValidationArgs(ci),
+    typecheckDirs: loadTypecheckDirs(ci),
+    coverage: loadCoverageSteps(ci),
+    codecovFlags: loadCodecovFlags(),
+    lintDomains: loadLintDomains(),
+  };
+}
+
+function main() {
+  let input;
+  try {
+    input = loadAll();
+  } catch (err) {
+    process.stderr.write(`check-ci-job-lists: FAIL\n\n  • ${err.message}\n\n`);
+    process.exit(1);
+  }
+
+  const byList = check(input);
+  const total = [...byList.values()].reduce((n, f) => n + f.length, 0);
+
+  if (total === 0) {
+    // Keep success output minimal so the pre-commit hook feels invisible.
+    process.stdout.write(
+      `check-ci-job-lists: OK (${input.exportArgs.length} export-validated, ` +
+        `${input.typecheckDirs.length} typechecked, ${input.codecovFlags.size} coverage flags, ` +
+        `${input.lintDomains.length} lint domains)\n`
+    );
+    process.exit(0);
+  }
+
+  process.stderr.write('check-ci-job-lists: FAIL\n\n');
+  for (const [listName, failures] of byList) {
+    if (failures.length === 0) continue;
+    process.stderr.write(`── ${listName} (${failures.length}) ──\n\n`);
+    for (const msg of failures) process.stderr.write(`  • ${msg}\n\n`);
+  }
+  process.exit(1);
+}
+
+if (require.main === module) {
+  main();
+}
+
+// Export for tests.
+module.exports = {
+  ENTRY_POINT_FIELDS,
+  INTENTIONAL_OMISSIONS,
+  check,
+  checkCoverage,
+  checkExportValidation,
+  checkLintDomains,
+  checkTypecheck,
+  joinContinuedLine,
+  loadAll,
+  loadCiBuiltPackages,
+  loadCodecovFlags,
+  loadCoverageSteps,
+  loadExportValidationArgs,
+  loadLintDomains,
+  loadTypecheckDirs,
+  loadWorkspaces,
+};

--- a/scripts/check-ci-job-lists.test.cjs
+++ b/scripts/check-ci-job-lists.test.cjs
@@ -1,0 +1,602 @@
+#!/usr/bin/env node
+/**
+ * Tests for scripts/check-ci-job-lists.cjs
+ *
+ * node's built-in runner, to keep the zero-runtime-deps story — no vitest, no
+ * jest, no extra install. Run with:
+ *     node --test scripts/check-ci-job-lists.test.cjs
+ */
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  check,
+  checkCoverage,
+  checkExportValidation,
+  checkLintDomains,
+  checkTypecheck,
+  joinContinuedLine,
+  loadAll,
+  loadCiBuiltPackages,
+  loadCodecovFlags,
+  loadCoverageSteps,
+  loadExportValidationArgs,
+  loadLintDomains,
+  loadTypecheckDirs,
+  loadWorkspaces,
+} = require('./check-ci-job-lists.cjs');
+
+/** Build a workspaces map matching the shape the check functions expect. */
+function workspaces(defs) {
+  const byDir = new Map();
+  for (const {
+    dir,
+    name = `@x/${dir}`,
+    isPrivate = false,
+    hasEntryPoint = true,
+    hasTypecheck = false,
+    hasTest = true,
+    hasLintSuite = false,
+  } of defs) {
+    byDir.set(dir, { name, isPrivate, hasEntryPoint, hasTypecheck, hasTest, hasLintSuite });
+  }
+  return byDir;
+}
+
+/**
+ * Synthetic fixtures must not inherit the real INTENTIONAL_OMISSIONS maps —
+ * their contents change as packages are vetted, and every entry would fire the
+ * stale-exemption class against a fixture workspace that has no such directory.
+ */
+const NONE = new Map();
+
+/**
+ * A miniature ci.yml carrying every shape that matters: the wrapped
+ * `if ! … | tee` export invocation with a `\`-continued arg list, a `run: |`
+ * typecheck block containing the `typecheck:scripts` near-miss, the coverage
+ * job's two step spellings, and prose that must not parse as a step.
+ */
+const SAMPLE_CI = [
+  'name: CI',
+  'jobs:',
+  '  build:',
+  '    steps:',
+  '      - name: Build alpha',
+  '        run: npm run build --prefix packages/alpha',
+  '      - name: Build beta',
+  '        run: npm run build:browser --prefix packages/beta',
+  '',
+  '  export-validation:',
+  '    steps:',
+  '      - name: Validate all package exports',
+  '        run: |',
+  '          set -o pipefail',
+  '          if ! node scripts/validate-exports.mjs \\',
+  '            alpha \\',
+  '            beta \\',
+  '            --strict 2>&1 | tee /tmp/export-validation.log; then',
+  '            status=1',
+  '          fi',
+  '',
+  '  # ============================================',
+  '  # Job 3: Lint & Typecheck',
+  '  # ============================================',
+  '  lint-typecheck:',
+  '    steps:',
+  '      - name: Typecheck all packages',
+  '        run: |',
+  '          npm run typecheck --prefix packages/alpha',
+  '          npm run typecheck --prefix packages/beta',
+  '      - name: Typecheck core scripts',
+  '        run: npm run typecheck:scripts --prefix packages/alpha',
+  '',
+  '  coverage:',
+  '    steps:',
+  '      - name: Generate coverage - alpha',
+  '        run: VITEST_TIMEOUT=300 npm run test:coverage --prefix packages/alpha',
+  '      - name: Generate coverage - beta',
+  '        run: npm test --prefix packages/beta -- --coverage',
+  '      - name: Upload alpha coverage to Codecov',
+  '        uses: codecov/codecov-action@v7',
+  '        with:',
+  '          files: packages/alpha/coverage/lcov.info',
+  '          flags: alpha',
+  '          name: alpha-coverage',
+  '      - name: Upload beta coverage to Codecov',
+  '        uses: codecov/codecov-action@v7',
+  '        with:',
+  '          files: packages/beta/coverage/lcov.info',
+  '          flags: beta',
+  '',
+  '  unit-tests:',
+  '    steps:',
+  '      # NOTE: lint:domains is `npm test --prefix packages/domain-<x> -- --run lint`',
+  '      - name: Test alpha',
+  '        run: npm test --prefix packages/alpha',
+].join('\n');
+
+const SAMPLE_CODECOV = [
+  'codecov:',
+  '  require_ci_to_pass: yes',
+  '',
+  'flags:',
+  '  alpha:',
+  '    paths:',
+  '      - packages/alpha/src/**',
+  '    carryforward: true',
+  '  beta:',
+  '    paths:',
+  '      - packages/beta/src/**',
+  '    carryforward: true',
+  '',
+  'comment:',
+  '  layout: header',
+].join('\n');
+
+const SAMPLE_ROOT_PKG = JSON.stringify({
+  scripts: {
+    'lint:domains':
+      'for pkg in sql bdd; do npm test --prefix packages/domain-$pkg -- --run lint || exit 1; done',
+  },
+});
+
+// ---------------------------------------------------------------------------
+// (1) export-validation
+// ---------------------------------------------------------------------------
+
+test('exports: passes when every qualifying package is an argument', () => {
+  const ws = workspaces([{ dir: 'a' }, { dir: 'b' }]);
+  const built = new Set(['a', 'b']);
+  assert.deepEqual(checkExportValidation(ws, built, ['a', 'b'], NONE), []);
+});
+
+test('exports: flags a qualifying package that is not validated', () => {
+  const ws = workspaces([{ dir: 'a' }, { dir: 'b', name: '@x/b' }]);
+  const failures = checkExportValidation(ws, new Set(['a', 'b']), ['a'], NONE);
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /@x\/b \(packages\/b\)/);
+  assert.match(failures[0], /NOT passed to validate-exports\.mjs/);
+  assert.match(failures[0], /Add "b" to the argument list/);
+});
+
+test('exports: flags a private package passed as an argument (the aot-compiler no-op)', () => {
+  const ws = workspaces([{ dir: 'a' }, { dir: 'priv', isPrivate: true }]);
+  const failures = checkExportValidation(ws, new Set(['a', 'priv']), ['a', 'priv'], NONE);
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /is private/);
+  assert.match(failures[0], /silent no-op/);
+});
+
+test('exports: a private package is not required to be validated', () => {
+  const ws = workspaces([{ dir: 'a' }, { dir: 'priv', isPrivate: true }]);
+  assert.deepEqual(checkExportValidation(ws, new Set(['a', 'priv']), ['a'], NONE), []);
+});
+
+test('exports: a package CI never builds is neither required nor allowed', () => {
+  const ws = workspaces([{ dir: 'a' }, { dir: 'unbuilt' }]);
+  // not required...
+  assert.deepEqual(checkExportValidation(ws, new Set(['a']), ['a'], NONE), []);
+  // ...and passing it anyway is a failure, because its dist never arrives.
+  const failures = checkExportValidation(ws, new Set(['a']), ['a', 'unbuilt'], NONE);
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /never builds it/);
+});
+
+test('exports: flags an argument naming no workspace package', () => {
+  const ws = workspaces([{ dir: 'a' }]);
+  const failures = checkExportValidation(ws, new Set(['a']), ['a', 'ghost'], NONE);
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /validates NOTHING and the job still passes/);
+});
+
+test('exports: flags a package with no entry-point field', () => {
+  const ws = workspaces([{ dir: 'a' }, { dir: 'b', hasEntryPoint: false }]);
+  const failures = checkExportValidation(ws, new Set(['a', 'b']), ['a', 'b'], NONE);
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /declares none of/);
+});
+
+test('exports: flags a duplicated argument', () => {
+  const ws = workspaces([{ dir: 'a' }]);
+  const failures = checkExportValidation(ws, new Set(['a']), ['a', 'a'], NONE);
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /twice/);
+});
+
+test('exports: an omission suppresses the missing-package failure', () => {
+  const ws = workspaces([{ dir: 'a' }, { dir: 'b' }]);
+  const omit = new Map([['b', 'ships prebuilt']]);
+  assert.deepEqual(checkExportValidation(ws, new Set(['a', 'b']), ['a'], omit), []);
+});
+
+test('exports: flags a stale omission that is now validated', () => {
+  const ws = workspaces([{ dir: 'a' }]);
+  const omit = new Map([['a', 'stale']]);
+  const failures = checkExportValidation(ws, new Set(['a']), ['a'], omit);
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /now includes it/);
+});
+
+test('exports: flags an omission for a package that no longer qualifies', () => {
+  const ws = workspaces([{ dir: 'a' }, { dir: 'b', isPrivate: true }]);
+  const omit = new Map([['b', 'stale']]);
+  const failures = checkExportValidation(ws, new Set(['a', 'b']), ['a'], omit);
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /the exemption is doing nothing/);
+});
+
+test('exports: flags an omission for a package that no longer exists', () => {
+  const ws = workspaces([{ dir: 'a' }]);
+  const omit = new Map([['ghost', 'stale']]);
+  const failures = checkExportValidation(ws, new Set(['a']), ['a'], omit);
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /no such workspace package exists/);
+});
+
+// ---------------------------------------------------------------------------
+// (2) typecheck
+// ---------------------------------------------------------------------------
+
+test('typecheck: passes when every package with the script is enumerated', () => {
+  const ws = workspaces([
+    { dir: 'a', hasTypecheck: true },
+    { dir: 'b', hasTypecheck: true },
+  ]);
+  assert.deepEqual(checkTypecheck(ws, ['a', 'b'], NONE), []);
+});
+
+test('typecheck: flags a package with a typecheck script CI never runs', () => {
+  const ws = workspaces([
+    { dir: 'a', hasTypecheck: true },
+    { dir: 'b', hasTypecheck: true },
+  ]);
+  const failures = checkTypecheck(ws, ['a'], NONE);
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /stays green forever/);
+  assert.match(failures[0], /npm run typecheck --prefix packages\/b/);
+});
+
+test('typecheck: a package without the script is not required', () => {
+  const ws = workspaces([{ dir: 'a', hasTypecheck: true }, { dir: 'b' }]);
+  assert.deepEqual(checkTypecheck(ws, ['a'], NONE), []);
+});
+
+test('typecheck: flags an enumerated package with no typecheck script', () => {
+  const ws = workspaces([{ dir: 'a', hasTypecheck: true }, { dir: 'b' }]);
+  const failures = checkTypecheck(ws, ['a', 'b'], NONE);
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /has no "typecheck" script/);
+});
+
+test('typecheck: flags an enumerated package that does not exist', () => {
+  const ws = workspaces([{ dir: 'a', hasTypecheck: true }]);
+  const failures = checkTypecheck(ws, ['a', 'ghost'], NONE);
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /no such workspace package exists/);
+});
+
+test('typecheck: flags a duplicated line', () => {
+  const ws = workspaces([{ dir: 'a', hasTypecheck: true }]);
+  const failures = checkTypecheck(ws, ['a', 'a'], NONE);
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /twice/);
+});
+
+test('typecheck: an omission suppresses the never-run failure, and goes stale', () => {
+  const ws = workspaces([
+    { dir: 'a', hasTypecheck: true },
+    { dir: 'b', hasTypecheck: true },
+  ]);
+  assert.deepEqual(checkTypecheck(ws, ['a'], new Map([['b', 'needs codegen']])), []);
+  const stale = checkTypecheck(ws, ['a', 'b'], new Map([['b', 'needs codegen']]));
+  assert.equal(stale.length, 1);
+  assert.match(stale[0], /now includes it/);
+});
+
+// ---------------------------------------------------------------------------
+// (3) coverage ⇔ codecov.yml
+// ---------------------------------------------------------------------------
+
+/** Build the {generates, uploads} shape loadCoverageSteps returns. */
+function coverage(generateDirs, uploads) {
+  return {
+    generates: generateDirs.map(dir => ({ dir, command: `npm test --prefix packages/${dir}` })),
+    uploads: uploads.map(u => (typeof u === 'string' ? { dir: u, flag: u } : u)),
+  };
+}
+
+/** Build the codecov flags map with the conventional paths for each flag. */
+function flags(names) {
+  return new Map(names.map(n => [n, { paths: [`packages/${n}/src/**`], carryforward: true }]));
+}
+
+test('coverage: passes when generate, upload and codecov.yml all agree', () => {
+  const ws = workspaces([{ dir: 'a' }, { dir: 'b' }]);
+  assert.deepEqual(checkCoverage(ws, coverage(['a', 'b'], ['a', 'b']), flags(['a', 'b'])), []);
+});
+
+test('coverage: flags an uploaded flag codecov.yml never declares (the language-server gap)', () => {
+  const ws = workspaces([{ dir: 'a' }, { dir: 'b' }]);
+  const failures = checkCoverage(ws, coverage(['a', 'b'], ['a', 'b']), flags(['a']));
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /uploads flag "b", which codecov\.yml never declares/);
+  assert.match(failures[0], /packages\/b\/src/);
+});
+
+test('coverage: flags a declared flag nothing uploads (the carryforward trap)', () => {
+  const ws = workspaces([{ dir: 'a' }]);
+  const failures = checkCoverage(ws, coverage(['a'], ['a']), flags(['a', 'ghost']));
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /declares flag "ghost", but the coverage job never uploads it/);
+  assert.match(failures[0], /carryforward: true/);
+});
+
+test('coverage: flags a generate step with no upload', () => {
+  const ws = workspaces([{ dir: 'a' }, { dir: 'b' }]);
+  const failures = checkCoverage(ws, coverage(['a', 'b'], ['a']), flags(['a']));
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /generates coverage for packages\/b but never uploads it/);
+});
+
+test('coverage: flags an upload step with no generate', () => {
+  const ws = workspaces([{ dir: 'a' }, { dir: 'b' }]);
+  const failures = checkCoverage(ws, coverage(['a'], ['a', 'b']), flags(['a', 'b']));
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /uploads packages\/b\/coverage\/lcov\.info but never generates it/);
+});
+
+test('coverage: flags an upload whose flag does not name its package', () => {
+  const ws = workspaces([{ dir: 'a' }, { dir: 'b' }]);
+  const cov = coverage(['a', 'b'], ['a', { dir: 'b', flag: 'a' }]);
+  const failures = checkCoverage(ws, cov, flags(['a', 'b']));
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /under flag "a"/);
+  assert.match(failures[0], /silently attributes one package's lines to another/);
+});
+
+test('coverage: flags an upload with no flags key at all', () => {
+  const ws = workspaces([{ dir: 'a' }]);
+  const cov = coverage(['a'], [{ dir: 'a', flag: null }]);
+  const failures = checkCoverage(ws, cov, new Map());
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /no `flags:` key/);
+});
+
+test('coverage: flags a package that does not exist', () => {
+  const ws = workspaces([{ dir: 'a' }]);
+  const failures = checkCoverage(ws, coverage(['ghost'], []), new Map());
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /packages\/ghost does not exist/);
+});
+
+test('coverage: flags a codecov flag whose paths point elsewhere', () => {
+  const ws = workspaces([{ dir: 'a' }]);
+  const wrong = new Map([['a', { paths: ['packages/b/src/**'], carryforward: true }]]);
+  const failures = checkCoverage(ws, coverage(['a'], ['a']), wrong);
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /disagree about what it covers/);
+});
+
+// ---------------------------------------------------------------------------
+// (4) lint:domains
+// ---------------------------------------------------------------------------
+
+test('lint:domains: passes when every domain with a lint suite is in the loop', () => {
+  const ws = workspaces([
+    { dir: 'domain-sql', hasLintSuite: true },
+    { dir: 'domain-bdd', hasLintSuite: true },
+  ]);
+  assert.deepEqual(checkLintDomains(ws, ['sql', 'bdd'], NONE), []);
+});
+
+test('lint:domains: flags a domain with a lint suite the loop skips', () => {
+  const ws = workspaces([
+    { dir: 'domain-sql', hasLintSuite: true },
+    { dir: 'domain-new', name: '@x/domain-new', hasLintSuite: true },
+  ]);
+  const failures = checkLintDomains(ws, ['sql'], NONE);
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /owns a lint\.test\.ts but is not in the root "lint:domains" loop/);
+  assert.match(failures[0], /Add "new"/);
+});
+
+test('lint:domains: a domain package without a lint suite is not required', () => {
+  const ws = workspaces([{ dir: 'domain-sql', hasLintSuite: true }, { dir: 'domain-toolkit' }]);
+  assert.deepEqual(checkLintDomains(ws, ['sql'], NONE), []);
+});
+
+test('lint:domains: flags a listed suffix with no such package', () => {
+  const ws = workspaces([{ dir: 'domain-sql', hasLintSuite: true }]);
+  const failures = checkLintDomains(ws, ['sql', 'ghost'], NONE);
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /the loop exits 1 on a healthy tree/);
+});
+
+test('lint:domains: flags a listed package with no lint suite', () => {
+  const ws = workspaces([{ dir: 'domain-sql', hasLintSuite: true }, { dir: 'domain-toolkit' }]);
+  const failures = checkLintDomains(ws, ['sql', 'toolkit'], NONE);
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /has no lint\.test\.ts under src\//);
+});
+
+test('lint:domains: flags a duplicated suffix', () => {
+  const ws = workspaces([{ dir: 'domain-sql', hasLintSuite: true }]);
+  const failures = checkLintDomains(ws, ['sql', 'sql'], NONE);
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /twice/);
+});
+
+test('lint:domains: an omission suppresses the skipped-domain failure', () => {
+  const ws = workspaces([
+    { dir: 'domain-sql', hasLintSuite: true },
+    { dir: 'domain-new', hasLintSuite: true },
+  ]);
+  const omit = new Map([['domain-new', 'quarantined']]);
+  assert.deepEqual(checkLintDomains(ws, ['sql'], omit), []);
+});
+
+// ---------------------------------------------------------------------------
+// Loaders
+// ---------------------------------------------------------------------------
+
+test('joinContinuedLine: follows backslash continuations and stops after', () => {
+  // Whitespace between joined fragments is not normalised (callers split on
+  // /\s+/); what matters is which tokens survive and where it stops.
+  const tokens = text => joinContinuedLine(text).trim().split(/\s+/);
+  assert.deepEqual(tokens(' a \\\n  b \\\n  c\n  d'), ['a', 'b', 'c']);
+  assert.deepEqual(tokens(' a b\n c d'), ['a', 'b']);
+});
+
+test('loadExportValidationArgs: reads a wrapped, multi-line argument list', () => {
+  assert.deepEqual(loadExportValidationArgs(SAMPLE_CI), ['alpha', 'beta']);
+});
+
+test('loadExportValidationArgs: stops at the first flag', () => {
+  const args = loadExportValidationArgs(SAMPLE_CI);
+  assert.ok(!args.includes('--strict'), 'flags must not be read as packages');
+  assert.ok(!args.some(a => a.includes('tee')), 'shell must not be read as packages');
+});
+
+test('loadExportValidationArgs: a removed invocation is a hard error', () => {
+  const gutted = SAMPLE_CI.replace('node scripts/validate-exports.mjs', 'echo skipped');
+  assert.throws(() => loadExportValidationArgs(gutted), /does not invoke/);
+});
+
+test('loadExportValidationArgs: an argument-less invocation is a hard error', () => {
+  // With no filter validate-exports validates EVERY package, including ones
+  // CI never builds — a green-looking gate that would fail for the wrong reason.
+  const unfiltered = SAMPLE_CI.replace(
+    /if ! node scripts\/validate-exports\.mjs \\\n.*\\\n.*\\\n.*then/s,
+    'if ! node scripts/validate-exports.mjs --strict; then'
+  );
+  assert.throws(() => loadExportValidationArgs(unfiltered), /invoked with no package arguments/);
+});
+
+test('loadTypecheckDirs: reads the run-block lines', () => {
+  assert.deepEqual(loadTypecheckDirs(SAMPLE_CI), ['alpha', 'beta']);
+});
+
+test('loadTypecheckDirs: `typecheck:scripts` is not a 3rd package', () => {
+  // The separate core-scripts step shares the prefix; requiring whitespace
+  // after `typecheck` is what keeps it out.
+  const dirs = loadTypecheckDirs(SAMPLE_CI);
+  assert.equal(dirs.filter(d => d === 'alpha').length, 1);
+});
+
+test('loadTypecheckDirs: an emptied step is a hard error, not a silent pass', () => {
+  const emptied = SAMPLE_CI.replace(
+    /^ +npm run typecheck --prefix packages\/\w+$/gm,
+    '          true'
+  );
+  assert.throws(() => loadTypecheckDirs(emptied), /has no .*npm run typecheck --prefix/);
+});
+
+test('loadCiBuiltPackages: reads the build job, ignoring other jobs', () => {
+  const built = loadCiBuiltPackages(SAMPLE_CI);
+  assert.deepEqual([...built].sort(), ['alpha', 'beta']);
+});
+
+test('loadCoverageSteps: reads both generate spellings and pairs uploads to flags', () => {
+  const { generates, uploads } = loadCoverageSteps(SAMPLE_CI);
+  assert.deepEqual(
+    generates.map(g => g.dir),
+    ['alpha', 'beta']
+  );
+  assert.deepEqual(uploads, [
+    { dir: 'alpha', flag: 'alpha' },
+    { dir: 'beta', flag: 'beta' },
+  ]);
+});
+
+test('loadCoverageSteps: does not read the unit-tests job', () => {
+  // `npm test --prefix packages/alpha` there has no `coverage` in it, and the
+  // job slice stops before it anyway; both belts are worth pinning.
+  const { generates } = loadCoverageSteps(SAMPLE_CI);
+  assert.equal(generates.length, 2);
+});
+
+test('loadCodecovFlags: parses flag names, paths and carryforward', () => {
+  const parsed = loadCodecovFlags(SAMPLE_CODECOV);
+  assert.deepEqual([...parsed.keys()], ['alpha', 'beta']);
+  assert.deepEqual(parsed.get('alpha').paths, ['packages/alpha/src/**']);
+  assert.equal(parsed.get('beta').carryforward, true);
+});
+
+test('loadCodecovFlags: the block stops at the next top-level key', () => {
+  const parsed = loadCodecovFlags(SAMPLE_CODECOV);
+  assert.ok(!parsed.has('layout'), 'the comment: block must not leak in');
+});
+
+test('loadCodecovFlags: a missing flags block is a hard error', () => {
+  assert.throws(() => loadCodecovFlags('codecov:\n  require_ci_to_pass: yes\n'), /no top-level/);
+});
+
+test('loadLintDomains: reads the shell loop suffixes', () => {
+  assert.deepEqual(loadLintDomains(SAMPLE_ROOT_PKG), ['sql', 'bdd']);
+});
+
+test('loadLintDomains: a reshaped script is a hard error, not an empty list', () => {
+  const reshaped = JSON.stringify({ scripts: { 'lint:domains': 'npm run lint --workspaces' } });
+  assert.throws(() => loadLintDomains(reshaped), /cannot parse "lint:domains"/);
+});
+
+test('loadLintDomains: a removed script is a hard error', () => {
+  assert.throws(() => loadLintDomains(JSON.stringify({ scripts: {} })), /no "lint:domains" script/);
+});
+
+// ---------------------------------------------------------------------------
+// Integration — the real repository
+// ---------------------------------------------------------------------------
+
+test('integration: real repository state passes all four checks', () => {
+  const byList = check(loadAll());
+  for (const [listName, failures] of byList) {
+    assert.deepEqual(failures, [], `${listName} reported failures`);
+  }
+});
+
+test('integration: the loaders return non-trivial real lists', () => {
+  const input = loadAll();
+  assert.ok(input.byDir.size > 20, `expected >20 packages, got ${input.byDir.size}`);
+  assert.ok(input.builtInCi.size > 20, `expected >20 built packages, got ${input.builtInCi.size}`);
+  assert.ok(
+    input.exportArgs.length > 20,
+    `expected >20 export args, got ${input.exportArgs.length}`
+  );
+  assert.ok(
+    input.typecheckDirs.length > 20,
+    `expected >20 typechecks, got ${input.typecheckDirs.length}`
+  );
+  assert.ok(
+    input.codecovFlags.size >= 4,
+    `expected >=4 codecov flags, got ${input.codecovFlags.size}`
+  );
+  assert.equal(input.lintDomains.length, 9, 'the nine-domain loop');
+  assert.ok(input.coverage.generates.length >= 4);
+  assert.ok(input.coverage.uploads.length >= 4);
+});
+
+test('integration: no real list names a package twice or a phantom package', () => {
+  const input = loadAll();
+  for (const [label, dirs] of [
+    ['export-validation', input.exportArgs],
+    ['typecheck', input.typecheckDirs],
+    ['coverage-generate', input.coverage.generates.map(g => g.dir)],
+  ]) {
+    assert.equal(new Set(dirs).size, dirs.length, `${label} names a package twice`);
+    for (const dir of dirs) {
+      assert.ok(input.byDir.has(dir), `${label} names packages/${dir}, which does not exist`);
+    }
+  }
+});
+
+test('integration: loadWorkspaces sees the domain lint suites on disk', () => {
+  // hasLintSuite is the one fact derived from the filesystem rather than
+  // package.json; a broken walk would silently make class (4) vacuous.
+  const byDir = loadWorkspaces();
+  const withSuites = [...byDir].filter(([, pkg]) => pkg.hasLintSuite).map(([dir]) => dir);
+  assert.equal(withSuites.length, 9, `expected 9 domain lint suites, got ${withSuites.join(', ')}`);
+});


### PR DESCRIPTION
Follow-up to #862, which guarded ci.yml's unit-test enumeration and named four more hand-written package lists as the natural next step. `scripts/check-ci-job-lists.cjs` (zero-dep, 56 self-tests) now fails on drift in all four.

## What had drifted

Three of the four. In each case the guard enumerated the real gap in one run, rather than the filing's estimate:

| List | Predicate | State before |
| ---- | --------- | ------------ |
| `export-validation` args | published **and** declares an entry point **and** built by the `build` job | **8 of 30** effective |
| `lint-typecheck` typecheck lines | has a `typecheck` script | **11 of 44** |
| nightly `coverage` job | flag declared in `codecov.yml`, both directions | `language-server` flag undeclared |
| root `lint:domains` loop | a `domain-*` owning a `lint.test.ts` | **9/9 — already correct** |

**export-validation checked 8 of the 30 packages that qualify.** Twenty-two published, CI-built packages — every `domain-*`, `framework`, `behaviors`, `hyperscript-adapter`, `htmx-adapter`, `intent`, `reactivity`, `realtime`, `server-bridge`, … — could ship a dangling `exports` path with nothing to catch it. The 9th argument, `aot-compiler`, is **private**, which `validate-exports.mjs` skips outright, so that argument had never done anything.

**"Typecheck all packages" ran 11 of 44** — the step name was aspirational. All 44 pass, and the full step measures ~28s vs ~9s for the 11, so the gap was coverage nobody was paying for.

**The coverage job uploads a `language-server` flag `codecov.yml` never declared**, so it got no `paths:` and no `carryforward`. The guard fails in *both* directions, because declared-but-never-uploaded is the worse half: `carryforward: true` makes Codecov serve that flag's last report forever, which reads as coverage rather than as absence.

`lint:domains` was already correct — that class is pure prevention. Its predicate is the only one derived from the filesystem, so it gets its own integration pin.

## A clean-checkout trap the expansion exposed

`packages/behaviors` has a gitignored `src/generated/`, so `tsc --noEmit` there fails on a fresh clone (TS2307 ×2). It had `prebuild` and `pretest` hooks but no `pretypecheck`; added. Same "working tree ≠ clean checkout" class that cost #862/#863 two CI round-trips — caught here by deleting the directory and re-running, not by reasoning about it.

## Verification

Every failure class mutation-verified against the **real** files, not just fixtures — each reddens exactly one row naming exactly that package:

- dropped `framework` from the export args → flagged
- dropped the `testing-framework` typecheck line → flagged
- removed the `language-server` flag from `codecov.yml` → flagged
- dropped `behaviorspec` from `lint:domains` → flagged
- added a `lint.test.ts` to `domain-toolkit` → flagged (the filesystem-derived class)

Both expanded CI steps were extracted from the workflow with a YAML parser and executed:

- export-validation step: exits 0, reports `Checking 30 package(s)` / `Skipped: 0`; and **still exits 1** when a package's export is broken, so the `\`-continued arg list does not defeat `pipefail`
- typecheck step: 44/44 green in 28s — and re-run against a **CI-like tree** (the 10 packages the `build` job never builds had their `dist/` removed) to confirm it does not depend on local build state

Also green: 56/56 self-tests, all four sibling guards and their self-tests, oxlint, prettier, and the behaviors suite (173 tests).

Wired into CI's `lint-typecheck` job and the pre-commit hook — which now watches the **root** `package.json` and `codecov.yml` too, unlike its three siblings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)