### PR TITLE
fix(semantic): `scroll to last <.message/> in #chat` — the swallowed destination marker (de/fr/ms/th/vi)

### DIFF
--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -24,6 +24,7 @@ import {
 } from '../types';
 import { stripOptionalDiacritics } from '@lokascript/framework';
 import { isTypeCompatible } from './utils/type-validation';
+import { ROLE_MARKER_CONCEPTS } from './utils/marker-resolution';
 import { commandSchemas, type CommandSchema } from '../generators/command-schemas';
 import { getPossessiveReference } from './utils/possessive-keywords';
 import {
@@ -1959,17 +1960,7 @@ export class PatternMatcher {
    * so this never blocks a genuine `my value` / `its style` possessive.
    */
   private isRoleMarkerConcept(normalized: string): boolean {
-    const markerConcepts = new Set([
-      'destination',
-      'source',
-      'patient',
-      'object',
-      'event',
-      'eventmarker',
-      'manner',
-      'instrument',
-    ]);
-    return markerConcepts.has(normalized.toLowerCase());
+    return ROLE_MARKER_CONCEPTS.has(normalized.toLowerCase());
   }
 
   /**

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -38,6 +38,7 @@ import {
 import { getPatternsForLanguage, tryGetProfile } from '../registry';
 import { getSchema } from '../generators/command-schemas';
 import { joinExpressionTokens } from './utils/expression-lexicon';
+import { ROLE_MARKER_CONCEPTS } from './utils/marker-resolution';
 import { patternMatcher } from './pattern-matcher';
 import { curatedEndKeywordSet } from './end-keywords';
 import { tryParseBlock, tryParseFeatureBlock, tryParseProgram } from './block-parser';
@@ -2065,11 +2066,33 @@ export class SemanticParserImpl implements ISemanticParser {
                 spec.expectedTypes.length > 0 && !spec.expectedTypes.includes(valType(val) as never)
               );
             };
+            // A fused capture is provably JUNK — a swallowed role MARKER, not an
+            // argument — when its literal value is a role-marker CONCEPT name.
+            // The fused event shape hardwires a required `{patient}` slot
+            // (`generators/event-handlers-vso.ts`), so on a schema that declares
+            // no patient role that slot lands on the destination MARKER of a
+            // corpus surface like `bei klick scrollen zu letzte <.message/> in
+            // #chat`; the marker keyword normalizes to its concept, and
+            // `tokenToSemanticValue` turns it into `literal="destination"`.
+            // No user ever writes a concept name as an argument, so this value
+            // can only be marker swallow — it must not veto the re-parse swap
+            // that recovers the real destination (`last <.message/> in #chat`).
+            // Scoped by the same no-real-`patient` condition as `mapRole`, so
+            // every genuine patient capture (increment, pick, the qu verb-final
+            // safety rail) keeps full superset protection.
+            const isMarkerConceptJunk = (role: string, val: unknown): boolean =>
+              role === 'patient' &&
+              !!schema &&
+              !schema.roles.some(r => r.role === 'patient') &&
+              valType(val) === 'literal' &&
+              ROLE_MARKER_CONCEPTS.has(
+                String((val as { value?: unknown }).value ?? '').toLowerCase()
+              );
             const preservesFused =
               !!first &&
               first.kind === 'command' &&
               Object.entries(roles).every(([role, val]) => {
-                if (isIgnorableFusedRole(role, val)) return true;
+                if (isIgnorableFusedRole(role, val) || isMarkerConceptJunk(role, val)) return true;
                 const rv = (first as CommandSemanticNode).roles.get(mapRole(role));
                 if (rv !== undefined && valType(rv) === valType(val)) return true;
                 // Pick's fused patterns bind the unit/variant word under the
@@ -2116,7 +2139,13 @@ export class SemanticParserImpl implements ISemanticParser {
               first.action === actionName &&
               preservesFused &&
               headOnlyOk &&
-              (first as CommandSemanticNode).roles.size > Object.keys(roles).length
+              // Strictly-more: the re-parse must recover something the fused
+              // capture lacked. Junk marker captures are excluded from the
+              // count — a fused shape whose ONLY role is a swallowed marker
+              // (scroll: `destination:literal="destination"`) would otherwise
+              // tie 1 > 1 and veto its own repair.
+              (first as CommandSemanticNode).roles.size >
+                Object.entries(roles).filter(([r, v]) => !isMarkerConceptJunk(r, v)).length
             ) {
               commandNode = first as CommandSemanticNode;
               while (tokens.position() < clauseEnd) tokens.advance();

--- a/packages/semantic/src/parser/utils/index.ts
+++ b/packages/semantic/src/parser/utils/index.ts
@@ -17,6 +17,7 @@ export {
   resolveMarkerForRole,
   getAllMarkersForRole,
   getDefaultRoleMarker,
+  ROLE_MARKER_CONCEPTS,
   type RoleSpecWithMarker,
   type ResolvedMarker,
 } from './marker-resolution';

--- a/packages/semantic/src/parser/utils/marker-resolution.ts
+++ b/packages/semantic/src/parser/utils/marker-resolution.ts
@@ -171,3 +171,26 @@ export function getDefaultRoleMarker(
 ): RoleMarker | undefined {
   return profile.roleMarkers[role];
 }
+
+/**
+ * The role-concept names a marker token normalizes to.
+ *
+ * A language's role markers (de `zu`, ms `ke`, ja `に`) tokenize as keywords
+ * whose `normalized` form is the CONCEPT they mark — `destination`, `source`,
+ * … — not a word any user ever wrote. Two consumers need to recognize that:
+ * `PatternMatcher.isRoleMarkerConcept` (a possessive head normalizing to one is
+ * a mis-read) and the fused body-walk swap in `SemanticParser` (a capture whose
+ * literal value IS a concept name can only be a swallowed marker).
+ *
+ * Shared so the two cannot drift apart.
+ */
+export const ROLE_MARKER_CONCEPTS: ReadonlySet<string> = new Set([
+  'destination',
+  'source',
+  'patient',
+  'object',
+  'event',
+  'eventmarker',
+  'manner',
+  'instrument',
+]);

--- a/packages/semantic/test/fused-marker-swallow-swap.test.ts
+++ b/packages/semantic/test/fused-marker-swallow-swap.test.ts
@@ -1,0 +1,193 @@
+/**
+ * `scroll to last <.message/> in #chat` — the swallowed destination marker.
+ *
+ * The generated fused event pattern (`<cmd>-event-<lang>-vso`, built by
+ * `generators/event-handlers-vso.ts`) hardwires a REQUIRED `{patient}` slot
+ * ahead of its optional destination group. `scrollSchema` declares no patient
+ * role, so on a corpus surface like `bei klick scrollen zu letzte <.message/>
+ * in #chat` that required slot lands on the destination MARKER (`zu`). The
+ * marker is a keyword whose `normalized` form is its role CONCEPT, so
+ * `tokenToSemanticValue` produced `literal="destination"` — the parse kept the
+ * verb, reported a destination, and left the real one
+ * (`letzte <.message/> in #chat`) unconsumed.
+ *
+ * Which languages this hits is a tokenizer accident, not a grammar fact:
+ * de `zu` / fr `à` / ms `ke` / th `ใน` / vi `vào` classify as KEYWORDS (→ a
+ * concept literal, capture succeeds, junk wins), while it/id/pt/ru/uk markers
+ * classify as PARTICLES (→ `null`, the required slot fails, the fused pattern
+ * never matches and those languages take the two-pattern route). es escapes for
+ * a third reason: its marker `a` is a particle AND an `ENGLISH_NOISE_WORD`, so
+ * `skipNoiseWords` steps over it before the positional head.
+ *
+ * The repair already existed. The fused body walk re-parses its clause through
+ * the standalone command patterns and swaps the result in — all five clause
+ * slices re-parse at confidence 1.0 to exactly the en roles — and that swap
+ * already heals this same junk for `go-url` (`gehen zu url "/page"`, whose
+ * fused patient is the same `literal="destination"`). Two vetoes blocked scroll
+ * from it, and BOTH had to go:
+ *
+ *   1. `preservesFused` — junk `literal` vs the re-parse's `expression` failed
+ *      the same-type check. `go-url` passes only by accident: its real
+ *      destination `"/page"` is a literal too.
+ *   2. the strictly-more size gate — scroll's fused capture has exactly one
+ *      role, so `1 > 1` is false and the repair vetoed itself. `go-url` clears
+ *      it at `2 > 1` because it also carries `method`.
+ *
+ * A capture whose literal value IS a role-concept name can only be a swallowed
+ * marker (no user writes `destination` as an argument), so both vetoes now
+ * exempt it — scoped by the same no-real-`patient` condition as the fused
+ * relabel, which is why every genuine patient capture below is untouched.
+ *
+ * MUTATION-VERIFIED: each exemption is independently load-bearing. Reverting
+ * only the `preservesFused` arm reddens all five rows below (destination goes
+ * back to `literal="destination"` + the unconsumed tail); reverting only the
+ * size-gate filter reddens the same five. Neither is redundant.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parse, parseSemantic } from '../src/index';
+import type { CommandSemanticNode } from '../src/types';
+
+function walkCommands(node: unknown): Array<{ action: string; roles: Map<string, unknown> }> {
+  const out: Array<{ action: string; roles: Map<string, unknown> }> = [];
+  const walk = (n: unknown): void => {
+    if (!n || typeof n !== 'object') return;
+    const rec = n as Record<string, any>;
+    if (rec.kind === 'command') out.push(rec as never);
+    for (const k of ['body', 'statements', 'thenBranch', 'elseBranch']) {
+      if (Array.isArray(rec[k])) rec[k].forEach(walk);
+    }
+  };
+  walk(node);
+  return out;
+}
+
+function commandNode(source: string, lang: string, action: string): CommandSemanticNode {
+  const node = parse(source, lang);
+  expect(node, `'${source}' (${lang}) did not parse`).not.toBeNull();
+  const hits = walkCommands(node).filter(c => c.action === action);
+  expect(hits.length, `'${source}' (${lang}) has no ${action} command`).toBeGreaterThan(0);
+  return hits[0] as unknown as CommandSemanticNode;
+}
+
+const roleType = (n: CommandSemanticNode, role: string): string | undefined =>
+  (n.roles.get(role as never) as { type?: string } | undefined)?.type;
+
+const roleSurface = (n: CommandSemanticNode, role: string): string | undefined => {
+  const v = n.roles.get(role as never) as { value?: unknown; raw?: string } | undefined;
+  return v === undefined ? undefined : String(v.raw ?? v.value);
+};
+
+function unconsumedSpans(code: string, language: string): string[] {
+  const node = parse(code, language);
+  return (node?.diagnostics ?? []).filter(d => d.code === 'unconsumed-input').map(d => d.message);
+}
+
+const EN_ROW = 'on click scroll to last <.message/> in #chat';
+const EN_DESTINATION = 'last <.message/> in #chat';
+
+/**
+ * The five `last-in-collection` corpus surfaces whose destination marker
+ * tokenizes as a keyword — verbatim from a freshly `populate`d patterns.db.
+ * These are the rows that were R1 role-lossy in the committed baseline.
+ */
+const MARKER_SWALLOW_ROWS: Array<[string, string]> = [
+  ['de', 'bei klick scrollen zu letzte <.message/> in #chat'],
+  ['fr', 'sur clic défiler à dernier <.message/> en #chat'],
+  ['ms', 'apabila click scroll ke terakhir <.message/> dalam #chat'],
+  ['th', 'เมื่อ คลิก เลื่อน ใน สุดท้าย <.message/> ใน #chat'],
+  ['vi', 'khi nhấp cuộn vào cuối cùng <.message/> trong #chat'],
+];
+
+describe('the en reference this row is scored against', () => {
+  it('keeps the whole positional query on `destination`', () => {
+    const scroll = commandNode(EN_ROW, 'en', 'scroll');
+    expect(roleType(scroll, 'destination')).toBe('expression');
+    expect(roleSurface(scroll, 'destination')).toBe(EN_DESTINATION);
+    expect(unconsumedSpans(EN_ROW, 'en')).toEqual([]);
+  });
+});
+
+describe('the marker-swallow languages recover the destination', () => {
+  it.each(MARKER_SWALLOW_ROWS)('%s parses the whole positional query', (lang, src) => {
+    // The clause must stay ONE scroll command — a recovered tail becoming a
+    // second phantom command would satisfy a role check but break the parse.
+    const node = parse(src, lang);
+    expect(walkCommands(node).map(c => c.action)).toEqual(['scroll']);
+
+    const scroll = commandNode(src, lang, 'scroll');
+    // The defect's signature: `literal="destination"`, the marker's own role
+    // CONCEPT name, standing in for the destination.
+    expect(roleSurface(scroll, 'destination')).not.toBe('destination');
+    expect(roleType(scroll, 'destination')).toBe('expression');
+    expect(roleSurface(scroll, 'destination')).toBe(EN_DESTINATION);
+  });
+
+  it.each(MARKER_SWALLOW_ROWS)('%s consumes its whole clause', (lang, src) => {
+    // The only witness the defect ever had: the real destination left over as
+    // a 4-token tail after the fused walk.
+    expect(unconsumedSpans(src, lang)).toEqual([]);
+  });
+
+  it.each(MARKER_SWALLOW_ROWS)('%s keeps the fused match adopted (confidence)', (lang, src) => {
+    // The repair is the SWAP, not a re-route: the fused pattern still wins its
+    // race at the same score. `parse()` reports no confidence — `parseSemantic`
+    // is the export that scores, and asserting through `parse` passes vacuously.
+    const result = parseSemantic(src, lang);
+    expect(result.node).not.toBeNull();
+    expect(result.confidence).toBeCloseTo(0.7142857142857143, 6);
+  });
+});
+
+describe('the exemption is scoped to provably-junk captures', () => {
+  /**
+   * `go-url` carries the identical swallowed marker, and its swap ALREADY
+   * fired before this change (junk literal vs real literal `/page` passed the
+   * type check; `2 > 1` cleared the size gate). Relaxing both vetoes must leave
+   * it byte-identical — this is the row that proves the change is additive.
+   */
+  const GO_URL_ROWS: Array<[string, string]> = [
+    ['en', 'on click go to url "/page"'],
+    ['de', 'bei klick gehen zu url "/page"'],
+    ['fr', 'sur clic aller à url "/page"'],
+    ['ms', 'apabila click pergi ke url "/page"'],
+    ['th', 'เมื่อ คลิก ไป ใน url "/page"'],
+    ['vi', 'khi nhấp đi đến url "/page"'],
+    ['es', 'en clic ir a url "/page"'],
+  ];
+
+  it.each(GO_URL_ROWS)('%s go-url keeps destination + method', (lang, src) => {
+    const go = commandNode(src, lang, 'go');
+    expect(roleType(go, 'destination')).toBe('literal');
+    expect(roleSurface(go, 'destination')).toBe('/page');
+    expect(roleSurface(go, 'method')).toBe('url');
+  });
+
+  it('es last-in-collection still escapes via the noise-word path', () => {
+    // es was never lossy: its marker `a` is a particle AND an ENGLISH_NOISE_WORD.
+    // It must not start depending on the exemption.
+    const src = 'en clic desplazar a último <.message/> en #chat';
+    const scroll = commandNode(src, 'es', 'scroll');
+    expect(roleType(scroll, 'destination')).toBe('expression');
+    expect(roleSurface(scroll, 'destination')).toBe(EN_DESTINATION);
+  });
+
+  it('a real patient capture on a patient-declaring schema is untouched', () => {
+    // The qu verb-final safety rail. `increment` DECLARES `patient`, so the
+    // no-real-patient clause makes the exemption unreachable here — the fronted
+    // `#score` keeps its full superset protection.
+    const inc = commandNode('#score ta ñitiy pi yapachiy 10', 'qu', 'increment');
+    expect(roleType(inc, 'patient')).toBe('selector');
+    expect(roleSurface(inc, 'patient')).toBe('#score');
+    expect(roleSurface(inc, 'quantity')).toBe('10');
+  });
+
+  it('the verb-final route to the same pattern is unaffected', () => {
+    // qu reaches `last-in-collection` through the SOV verb-anchoring fallback,
+    // not the fused VSO shape — it was already faithful and must stay so.
+    const src = 'qhipa <.message/> ukupi #chat man ñitiy pi kunray';
+    const scroll = commandNode(src, 'qu', 'scroll');
+    expect(roleType(scroll, 'destination')).toBe('expression');
+    expect(roleSurface(scroll, 'destination')).toBe(EN_DESTINATION);
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-08-01T01:36:10.542Z",
-  "commit": "cb752d5e",
+  "timestamp": "2026-08-01T13:49:56.045Z",
+  "commit": "c4185cf9",
   "languages": {
     "ar": {
       "parseSuccess": 155,
@@ -16,10 +16,8 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "pick-text-range"
-      ],
-      "bundleSize": 557470,
+      "roleLossyPatterns": ["pick-text-range"],
+      "bundleSize": 557658,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -657,11 +655,8 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "pick-text-range",
-        "take-class-from-siblings"
-      ],
-      "bundleSize": 557470,
+      "roleLossyPatterns": ["pick-text-range", "take-class-from-siblings"],
+      "bundleSize": 557658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1293,17 +1288,14 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9965367965367967,
+      "avgRoleFidelity": 0.9987012987012988,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "last-in-collection",
-        "pick-text-range"
-      ],
-      "bundleSize": 557470,
+      "roleLossyPatterns": ["pick-text-range"],
+      "bundleSize": 557658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1932,7 +1924,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 557470,
+      "bundleSize": 557658,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2570,10 +2562,8 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "pick-text-range"
-      ],
-      "bundleSize": 557470,
+      "roleLossyPatterns": ["pick-text-range"],
+      "bundleSize": 557658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3205,17 +3195,14 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9965367965367967,
+      "avgRoleFidelity": 0.9987012987012988,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "last-in-collection",
-        "pick-text-range"
-      ],
-      "bundleSize": 557470,
+      "roleLossyPatterns": ["pick-text-range"],
+      "bundleSize": 557658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3853,11 +3840,8 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "pick-text-range",
-        "set-attribute"
-      ],
-      "bundleSize": 557470,
+      "roleLossyPatterns": ["pick-text-range", "set-attribute"],
+      "bundleSize": 557658,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4495,11 +4479,8 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "pick-text-range",
-        "take-class-from-siblings"
-      ],
-      "bundleSize": 557470,
+      "roleLossyPatterns": ["pick-text-range", "take-class-from-siblings"],
+      "bundleSize": 557658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5143,7 +5124,7 @@
         "fetch-json",
         "pick-text-range"
       ],
-      "bundleSize": 557470,
+      "bundleSize": 557658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5781,11 +5762,8 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "pick-text-range",
-        "take-class-from-siblings"
-      ],
-      "bundleSize": 557470,
+      "roleLossyPatterns": ["pick-text-range", "take-class-from-siblings"],
+      "bundleSize": 557658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6423,11 +6401,8 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "pick-text-range",
-        "take-class-from-siblings"
-      ],
-      "bundleSize": 557470,
+      "roleLossyPatterns": ["pick-text-range", "take-class-from-siblings"],
+      "bundleSize": 557658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7071,7 +7046,7 @@
         "when-multiple-changes",
         "when-value-changes"
       ],
-      "bundleSize": 557470,
+      "bundleSize": 557658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7703,18 +7678,14 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9943722943722945,
+      "avgRoleFidelity": 0.9965367965367967,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "hide-with-transition",
-        "last-in-collection",
-        "pick-text-range"
-      ],
-      "bundleSize": 557470,
+      "roleLossyPatterns": ["hide-with-transition", "pick-text-range"],
+      "bundleSize": 557658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8352,11 +8323,8 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "pick-text-range",
-        "unless-condition"
-      ],
-      "bundleSize": 557470,
+      "roleLossyPatterns": ["pick-text-range", "unless-condition"],
+      "bundleSize": 557658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8994,10 +8962,8 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "pick-text-range"
-      ],
-      "bundleSize": 557470,
+      "roleLossyPatterns": ["pick-text-range"],
+      "bundleSize": 557658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9641,7 +9607,7 @@
         "pick-text-range",
         "take-class-from-siblings"
       ],
-      "bundleSize": 557470,
+      "bundleSize": 557658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10279,11 +10245,8 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "pick-text-range",
-        "take-class-from-siblings"
-      ],
-      "bundleSize": 557470,
+      "roleLossyPatterns": ["pick-text-range", "take-class-from-siblings"],
+      "bundleSize": 557658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10921,10 +10884,8 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "pick-text-range"
-      ],
-      "bundleSize": 557470,
+      "roleLossyPatterns": ["pick-text-range"],
+      "bundleSize": 557658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11556,18 +11517,14 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9952380952380954,
+      "avgRoleFidelity": 0.9974025974025975,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "last-in-collection",
-        "pick-text-range",
-        "toggle-aria-expanded"
-      ],
-      "bundleSize": 557470,
+      "roleLossyPatterns": ["pick-text-range", "toggle-aria-expanded"],
+      "bundleSize": 557658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12205,10 +12162,8 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "pick-text-range"
-      ],
-      "bundleSize": 557470,
+      "roleLossyPatterns": ["pick-text-range"],
+      "bundleSize": 557658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12846,11 +12801,8 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "pick-text-range",
-        "take-class-from-siblings"
-      ],
-      "bundleSize": 557470,
+      "roleLossyPatterns": ["pick-text-range", "take-class-from-siblings"],
+      "bundleSize": 557658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13488,11 +13440,8 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "pick-text-range",
-        "take-class-from-siblings"
-      ],
-      "bundleSize": 557470,
+      "roleLossyPatterns": ["pick-text-range", "take-class-from-siblings"],
+      "bundleSize": 557658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14124,7 +14073,7 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9939393939393941,
+      "avgRoleFidelity": 0.9961038961038964,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
@@ -14132,11 +14081,10 @@
       "lossyPasses": [],
       "roleLossyPatterns": [
         "its-value-possessive-dot",
-        "last-in-collection",
         "pick-text-range",
         "take-class-from-siblings"
       ],
-      "bundleSize": 557470,
+      "bundleSize": 557658,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14774,12 +14722,8 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "pick-text-range",
-        "repeat-forever",
-        "repeat-until-event"
-      ],
-      "bundleSize": 557470,
+      "roleLossyPatterns": ["pick-text-range", "repeat-forever", "repeat-until-event"],
+      "bundleSize": 557658,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15406,20 +15350,8 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 557470,
-      "languages": [
-        "en",
-        "es",
-        "pt",
-        "fr",
-        "de",
-        "ja",
-        "zh",
-        "ko",
-        "ar",
-        "tr",
-        "id"
-      ]
+      "size": 557658,
+      "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }
 }


### PR DESCRIPTION
## What

`last-in-collection` (`on click scroll to last <.message/> in #chat`) was R1
role-lossy in **de, fr, ms, th, vi** — 5 of the 52-row R1 burn-down tail. The
parse kept the verb but reported `scroll.destination:literal="destination"`
(the marker's own role CONCEPT name) and left the real destination unconsumed.

## Root cause — the generated fused shape, not the schema

`generators/event-handlers-vso.ts` hardwires a **required `{patient}` slot**
ahead of its optional destination group. `scrollSchema` declares no patient
role, so on `bei klick scrollen zu letzte <.message/> in #chat` the slot lands
on the marker `zu`; a marker keyword normalizes to its concept, and
`tokenToSemanticValue` turns it into `literal="destination"`.

Which languages this hits is a **tokenizer accident**, not a grammar fact:

| escape route | languages | why |
| --- | --- | --- |
| none — lossy | de `zu`, fr `à`, ms `ke`, th `ใน`, vi `vào` | markers are KEYWORDS → concept literal, capture succeeds |
| fused pattern never matches | it, id, pt, ru, uk | markers are PARTICLES → `null` → required slot fails |
| noise-word skip | es | `a` is a particle AND an `ENGLISH_NOISE_WORD` |

## The fix — the repair already existed

The fused body walk re-parses its clause through the standalone patterns and
swaps the result in. All five clause slices re-parse at **confidence 1.0** to
exactly the en roles, and that swap **already heals this identical junk for
`go-url`**. Two vetoes blocked scroll from it, and both were load-bearing:

1. **`preservesFused`** — junk `literal` vs the re-parse's `expression` failed
   the same-type check. `go-url` passes only by accident: its real destination
   `"/page"` is a literal too.
2. **the strictly-more size gate** — scroll's fused capture has exactly one
   role, so `1 > 1` is false and the repair vetoed itself. `go-url` clears it
   at `2 > 1` via its `method` role.

A capture whose literal value **is** a role-concept name can only be a
swallowed marker — no user writes `destination` as an argument — so both vetoes
now exempt it, scoped by the same no-real-`patient` condition as the fused
relabel.

**Nothing in the matcher or the generator changed.** Every pattern's match
outcome, priority, and confidence is byte-identical; the repair is the swap.
That rules out the two alternatives: a `matchRoleToken` skip-guard fires on 4
currently-healthy `go-url` rows and drops fused confidence toward the 0.7
adoption threshold, and a generator change touches every language × every
no-patient command.

## Measured, not argued

A **whole-corpus pre/post probe** over all **3960** stored patterns.db rows (24
languages × the full pattern set, reading stored rows — not `translate()`)
diffs to **exactly the five target rows and nothing else**:

```
< de  last-in-collection  S=[on.event:literal|scroll.destination:literal]   L=[…,scroll.destination=destination]
> de  last-in-collection  S=[on.event:literal|scroll.destination:expression] L=[on.event=click]
   (…fr, ms, th, vi identical; 3955 other rows byte-identical)
```

Marker-concept literals remaining anywhere in the corpus: **5 → 0**.

## Test lock

`packages/semantic/test/fused-marker-swallow-swap.test.ts` (26 assertions). The
5 corpus surfaces verbatim; actions exactly `['scroll']` (a recovered tail
becoming a phantom command would satisfy a role check but break the parse);
destination is `expression` = `last <.message/> in #chat` and explicitly not
the string `"destination"`; `unconsumedSpans === []`; confidence pinned through
`parseSemantic` (not `parse(...).confidence`, which is `undefined` and passes
vacuously). Guard rows: all 7 `go-url` surfaces unchanged, es's noise-word
escape, and the qu `#score` verb-final safety rail.

**Both exemption arms independently mutation-verified** — reverting either one
alone reddens the same 10 behavioral rows.

## Baseline diff — three kinds of line, no others

- header (`timestamp`/`commit`)
- mechanical `bundleSize` 557470 → 557658 on all 24 blocks
- the five languages drop `last-in-collection` from `roleLossyPatterns`;
  `avgRoleFidelity` +0.00216 each (de/fr 0.9965→0.9987, ms 0.9944→0.9965,
  th 0.9952→0.9974, vi 0.9939→0.9961)

No parse-rate, R0, precision, multiset-recall, value-recall, R2, R4 or R5
movement.

## Gates

Multilingual `--regression` green · `test:canonical` 7/7 (both allowlists still
empty) · semantic 7382 tests / 112 files · root `test:check` 39 packages incl.
vocab consistency (0 unwaived), hyperscript-adapter syntax-table drift, and the
R2 curated-subset lock · `npm run lint` clean.

Parser-only change — no schema, profile, dict or tokenizer edit — so no
syntax-table regen, vocab waiver, `docs:commands` restage, or domain-voice
review applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
