### PR TITLE
fix(semantic): `pick characters 0 to 5 of #note` — the unit word's value type, R1-lossy in all 23 non-en languages

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -9,6 +9,41 @@
 > [BEHAVIORS_CONSOLIDATION_PLAN.md](BEHAVIORS_CONSOLIDATION_PLAN.md). Read this first,
 > then dive into those for the per-arc detail.
 
+---
+
+> **Update 2026-08-01 — the R1 burn-down tail went 52 → 24 rows in two PRs,
+> and BOTH were smaller than their filings claimed.**
+>
+> - **#867 · `last-in-collection` (5 rows: de/fr/ms/th/vi).** Not a schema gap.
+>   The generated fused event shape hardwires a required `{patient}` slot; on a
+>   schema with no patient role (`scroll`) it swallows the destination MARKER,
+>   whose keyword normalizes to its own role concept →
+>   `destination:literal="destination"` with the real destination left
+>   unconsumed. Which languages this hits is a **tokenizer accident**: the five
+>   have keyword-kind markers (capture succeeds, junk wins); it/id/pt/ru/uk have
+>   particle-kind markers (capture returns null, the fused pattern never
+>   matches); es's `a` is a particle AND an `ENGLISH_NOISE_WORD`. **The repair
+>   already existed** — the fused body-walk re-parse swap heals this identical
+>   junk for `go-url` — and was blocked by exactly two vetoes, both
+>   mutation-verified load-bearing: the `preservesFused` type check (junk
+>   `literal` vs the re-parse's `expression`; `go-url` passes only because its
+>   real destination is a literal too) and the strictly-more size gate (`1 > 1`
+>   for scroll's single junk role — the repair vetoed itself). Both now exempt
+>   captures whose literal value IS a role-concept name. **No matcher or
+>   generator change**, so every pattern's match outcome, priority and
+>   confidence is byte-identical.
+> - **#868 · `pick-text-range` (23 rows).** See the struck-through Family F
+>   deferral below — its cost estimate was stale, the realignment having landed
+>   in arcs 1–3. One valueType divergence, fixed via `ExtractionRule.transform`
+>   plus widening the fused-swap pick preservation clause.
+>
+> Both were sized by a **whole-corpus pre/post probe** (3960 stored patterns.db
+> rows, 24 languages × the full pattern set) and both diffed to exactly their
+> target rows and nothing else. **Seven languages are now at avgRoleFidelity
+> 1.0000 — ar, de, es, fr, pt, sw, tl.** What remains: the 10
+> `take.recipient` rows (#864's named i18n-rendering follow-up) and 14
+> scattered singletons — the "thin and flat" headroom by design.
+
 ## Where we are (2026-07-20 baseline `82fb5827` · post pick-text-range arc 3 · `browser-priority`)
 
 > ## 🎉 THE LAUNCH BAR IS COMPLETE (session 14 / L7)
@@ -206,13 +241,30 @@ fail CI.
 >
 > **Deferred, with reasons (the standing R1 tail):**
 >
-> - **pick-text-range (Family F, all six):** the en reference itself is
+> - ~~**pick-text-range (Family F, all six):** the en reference itself is
 >   degenerate (`pick.patient:expression="characters"` — the first WORD;
 >   pickSchema models no range/source roles), so chasing SOV parity buys
 >   nothing. The proper fix (pickSchema range roles + transformer render +
 >   SOV pattern variants) RAISES the en denominator for all 24 languages —
 >   the most expensive row in the tail for ×6 misses. Take it only if pick
->   matters for a demo; budget the full 24-language realignment.
+>   matters for a demo; budget the full 24-language realignment.~~
+>   **CLEARED 2026-08-01, PR #868 — and this deferral text was STALE when it
+>   was quoted back.** The 24-language realignment it budgets for had already
+>   been paid by arcs 1–3 (2026-07-20, three entries above): the en reference
+>   is not degenerate, `pickSchema` models the range via patterns, and all 24
+>   rows already round-tripped to byte-identical English. What remained was
+>   ONE valueType divergence, identical in all 23 non-en languages — `missing
+>   pick.method:expression / captured pick.method:literal` — because en keeps
+>   `characters` off its keyword list (identifier path → expression) while
+>   all 22 foreign tokenizers register it (keyword path → literal). Fixed in
+>   two halves: `ExtractionRule.transform` on the `method` slot of both pick
+>   factories (post-confidence, so no adoption score moved), plus widening the
+>   fused-swap pick preservation clause to compare `method` by SURFACE rather
+>   than type — without the second half the 13 fused-routing languages
+>   truncate to `pick characters` and the arc-3 R4 cluster re-opens. All 23
+>   languages left `roleLossyPatterns`; ar/es/pt/sw/tl reached R1 **1.0000**.
+>   **Lesson: a standing deferral's cost estimate ages with the arcs that land
+>   around it — re-measure the row before budgeting for the filing's scope.**
 > - **Reactive on.event rows (hi/ko when-value-changes +
 >   when-multiple-changes, hi window-resize, qu announce-screen-reader +
 >   on-custom-event-receive):** event-anchor guard machinery — the hottest

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -2100,18 +2100,29 @@ export class SemanticParserImpl implements ISemanticParser {
                 // "characters"), while the canonical pick variant pattern
                 // re-roles that word to `method` and captures the RANGE under
                 // `patient` (`0 to 5`). The unit word reappearing under
-                // `method` with the SAME literal value IS preservation — the
-                // role moved, nothing was lost. Without this the type check
-                // above (literal vs expression) vetoes the swap and the
-                // handler body truncates to `pick characters` (the arc-3
-                // foreign canonical-validity cluster).
+                // `method` with the SAME SURFACE is preservation — the role
+                // moved, nothing was lost. Without this the type check above
+                // (literal vs expression) vetoes the swap and the handler body
+                // truncates to `pick characters` (the arc-3 foreign
+                // canonical-validity cluster).
+                //
+                // The re-parsed `method` may be a literal or an EXPRESSION: the
+                // foreign pick patterns re-type unit words to the expression
+                // shape en produces (patterns/pick.ts). Compare surfaces, not
+                // types — a type check here would re-open the truncation
+                // cluster for all 13 verb-initial languages.
                 if (role === 'patient' && actionName === 'pick' && valType(val) === 'literal') {
                   const mv = (first as CommandSemanticNode).roles.get('method');
+                  const mvType = valType(mv);
+                  const mvSurface =
+                    mvType === 'literal'
+                      ? String((mv as { value?: unknown }).value)
+                      : mvType === 'expression'
+                        ? String((mv as { raw?: unknown }).raw)
+                        : undefined;
                   return (
-                    mv !== undefined &&
-                    valType(mv) === 'literal' &&
-                    String((mv as { value?: unknown }).value) ===
-                      String((val as { value?: unknown }).value)
+                    mvSurface !== undefined &&
+                    mvSurface === String((val as { value?: unknown }).value)
                   );
                 }
                 return false;

--- a/packages/semantic/src/patterns/pick.ts
+++ b/packages/semantic/src/patterns/pick.ts
@@ -42,7 +42,41 @@
  * corpus rows (the i18n-renders-semantic-patterns-coevolve lesson).
  */
 
-import type { LanguagePattern, PatternToken } from '../types';
+import {
+  createLiteral,
+  type LanguagePattern,
+  type PatternToken,
+  type SemanticValue,
+} from '../types';
+
+/**
+ * The unit words `pick (item|character)s <range> of <root>` selects BY. Mirrors
+ * the range variants the en pattern and the pick AST mapper recognize.
+ */
+const PICK_UNIT_WORDS = new Set(['character', 'characters', 'item', 'items']);
+
+/**
+ * Re-type a captured unit word to the shape the EN reference produces.
+ *
+ * En deliberately keeps `characters` off its keyword list (see
+ * patterns/languages/en/pick.ts) so it rides the identifier path and lands on
+ * `method` as an EXPRESSION. All 22 foreign tokenizers register it as a
+ * keyword, so `tokenToSemanticValue` builds a LITERAL instead. Nothing about
+ * the parse differs but that type — and role fidelity is compared by
+ * `action.role:valueType`, so the divergence read as a dropped role in all 23
+ * non-en languages (`missing pick.method:expression / captured instead:
+ * pick.method:literal`), the entire remaining pick-text-range R1 miss.
+ *
+ * Conditional on purpose. `first`/`last`/`random` ride this same slot and are
+ * keywords in EN too, so re-typing them would manufacture the inverse
+ * divergence. A numeric raw (a degenerate non-corpus match) is rebuilt numeric
+ * because `applyExtractionRules` hands the transform a String.
+ */
+const retypePickUnitWord = (raw: string): SemanticValue => {
+  if (PICK_UNIT_WORDS.has(raw)) return { type: 'expression', raw };
+  const n = Number(raw);
+  return createLiteral(raw !== '' && !Number.isNaN(n) ? n : raw);
+};
 
 /** Per-language surface knobs for the verb-initial pick variant pattern. */
 interface PickVariantSpec {
@@ -101,7 +135,7 @@ function makePickVariantPattern(language: string, spec: PickVariantSpec): Langua
       tokens,
     },
     extraction: {
-      method: { position: 1 },
+      method: { position: 1, transform: retypePickUnitWord },
       patient: { position: 2 },
       source: {
         marker: spec.srcMarker,
@@ -175,7 +209,7 @@ function makePickVerbFinalPattern(language: string, spec: PickVerbFinalSpec): La
     },
     extraction: {
       source: { position: 0 },
-      method: { position: 2 },
+      method: { position: 2, transform: retypePickUnitWord },
       patient: { position: 3 },
     },
   };

--- a/packages/semantic/test/pick-method-role-fidelity.test.ts
+++ b/packages/semantic/test/pick-method-role-fidelity.test.ts
@@ -1,0 +1,240 @@
+/**
+ * `pick characters 0 to 5 of #note` — the unit word's value TYPE.
+ *
+ * The expensive half of `pick-text-range` was paid across arcs 1–3: the en
+ * schema remodel + range assembler, the 24-language pick vocabulary, and the
+ * foreign/SOV variant patterns with the armed range fold. Both
+ * canonical-validity allowlists went empty and all 24 corpus rows round-trip to
+ * byte-identical English (`test/pick-command.test.ts`).
+ *
+ * What survived that was a single valueType divergence, and it made
+ * `pick-text-range` R1 role-lossy in ALL 23 non-en languages — the largest
+ * cluster in the burn-down tail, and for ar/es/pt/sw/tl the ONLY R1 miss they
+ * had:
+ *
+ *     missing  pick.method:expression      (the en reference)
+ *     captured pick.method:literal         (all 23 foreign parses)
+ *
+ * Every role was present, in the right slot, with the right value. Only the
+ * type differed, because the two sides reach `method` down different token
+ * paths: en deliberately keeps `characters` OFF its keyword list (see
+ * patterns/languages/en/pick.ts — keywording it would risk this pattern's
+ * identifier path), so it rides the identifier branch of
+ * `tokenToSemanticValue` and lands as an EXPRESSION; all 22 foreign tokenizers
+ * register it as a keyword, so it lands as a LITERAL. Role fidelity is compared
+ * as `action.role:valueType`, so that asymmetry alone read as a dropped role.
+ *
+ * The fix is two halves, and BOTH are required:
+ *
+ *  A. `patterns/pick.ts` re-types unit-word captures on the `method` slot of
+ *     both factories (verb-initial and SOV verb-final) via the existing
+ *     `ExtractionRule.transform` hook — which runs AFTER confidence scoring, so
+ *     no adoption decision can move. Conditional on the unit words only:
+ *     `first`/`last`/`random` ride the same slot and are keywords in en TOO, so
+ *     re-typing them would manufacture the inverse divergence (pinned below).
+ *  B. the pick preservation clause in `semantic-parser.ts` compares the
+ *     re-parsed `method` by SURFACE, not by type. It previously required
+ *     `literal`; with A applied, that veto killed the fused re-parse swap and
+ *     truncated the handler body to `on click pick characters` — the arc-3
+ *     canonical-validity cluster, re-opened. B alone is unobservable (it is a
+ *     strict widening); it is mutation-verified through A.
+ *
+ * MUTATION-VERIFIED: reverting A reddens the signature and method-type rows in
+ * all 23 languages. Reverting B alone (A in place) reddens 13 of them —
+ * de/es/fr/id/it/ms/pl/pt/ru/sw/th/uk/vi, the languages whose corpus row
+ * routes through the fused body-walk swap — including their round-trip rows,
+ * the truncation. The SOV six and ar/he/tl/zh never reach that swap and stay
+ * green, which is why B alone proves nothing without A.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parse, parseSemantic, render } from '../src/index';
+import { getSchema } from '../src/generators/command-schemas';
+import type { CommandSemanticNode } from '../src/types';
+
+function walkCommands(node: unknown): Array<{ action: string; roles: Map<string, unknown> }> {
+  const out: Array<{ action: string; roles: Map<string, unknown> }> = [];
+  const walk = (n: unknown): void => {
+    if (!n || typeof n !== 'object') return;
+    const rec = n as Record<string, any>;
+    if (rec.kind === 'command') out.push(rec as never);
+    for (const k of ['body', 'statements', 'thenBranch', 'elseBranch']) {
+      if (Array.isArray(rec[k])) rec[k].forEach(walk);
+    }
+  };
+  walk(node);
+  return out;
+}
+
+function pickNode(source: string, lang: string): CommandSemanticNode {
+  const node = parse(source, lang);
+  expect(node, `'${source}' (${lang}) did not parse`).not.toBeNull();
+  const picks = walkCommands(node).filter(c => c.action === 'pick');
+  expect(picks.length, `'${source}' (${lang}) has no pick command`).toBeGreaterThan(0);
+  return picks[0] as unknown as CommandSemanticNode;
+}
+
+/**
+ * The `action.role:valueType` set the multilingual harness compares languages
+ * by (mirrors `collectRoleSignature` in testing-framework's fidelity.ts —
+ * duplicated deliberately rather than imported, so this package's tests carry
+ * no cross-package dependency).
+ */
+function roleSignature(node: unknown): string[] {
+  const acc = new Set<string>();
+  const walk = (n: unknown, depth: number): void => {
+    if (!n || typeof n !== 'object' || depth > 12) return;
+    const o = n as Record<string, any>;
+    if (typeof o.action === 'string' && o.roles instanceof Map) {
+      for (const [role, value] of o.roles.entries()) {
+        const kind =
+          value && typeof value === 'object' && typeof value.type === 'string'
+            ? value.type
+            : typeof value;
+        acc.add(`${o.action}.${String(role)}:${kind}`);
+      }
+    }
+    for (const k of ['body', 'statements', 'thenBranch', 'elseBranch']) {
+      if (Array.isArray(o[k])) o[k].forEach((c: unknown) => walk(c, depth + 1));
+    }
+  };
+  walk(node, 0);
+  return [...acc].sort();
+}
+
+const roleType = (n: CommandSemanticNode, role: string): string | undefined =>
+  (n.roles.get(role as never) as { type?: string } | undefined)?.type;
+
+const roleSurface = (n: CommandSemanticNode, role: string): string | undefined => {
+  const v = n.roles.get(role as never) as { value?: unknown; raw?: string } | undefined;
+  return v === undefined ? undefined : String(v.raw ?? v.value);
+};
+
+const EN_ROW = 'on click pick characters 0 to 5 of #note';
+
+/**
+ * The `pick-text-range` corpus surfaces, verbatim from a freshly `populate`d
+ * patterns.db, with each language's measured `parseSemantic` confidence. The
+ * confidence is pinned because `ExtractionRule.transform` runs AFTER the
+ * confidence model — a fix that moved adoption scores would be a different,
+ * riskier change than the one made here.
+ *
+ * `verbFinal` marks the SOV six, which reach `pick` through the verb-final
+ * factory. They are the languages that stay green under the B-only mutation.
+ */
+const CORPUS: Array<{ lang: string; src: string; conf: number; verbFinal?: true }> = [
+  { lang: 'ar', src: 'اختر حروف 0 إلى 5 من #note عند نقر', conf: 0.75 },
+  { lang: 'bn', src: '#note র অক্ষর 0 থেকে 5 কে ক্লিক এ বাছুন', conf: 0.75, verbFinal: true },
+  { lang: 'de', src: 'bei klick auswählen Zeichen 0 zu 5 von #note', conf: 0.5555555555555556 },
+  { lang: 'es', src: 'en clic escoger caracteres 0 a 5 de #note', conf: 0.5555555555555556 },
+  { lang: 'fr', src: 'sur clic choisir caractères 0 à 5 de #note', conf: 0.5555555555555556 },
+  { lang: 'he', src: 'ב לחיצה בחר את תווים 0 על 5 of #note', conf: 0.8222222222222222 },
+  { lang: 'hi', src: '#note का अक्षर 0 से 5 को क्लिक पर चुनें', conf: 0.75, verbFinal: true },
+  { lang: 'id', src: 'pada klik pilih karakter 0 ke 5 dari #note', conf: 0.5555555555555556 },
+  { lang: 'it', src: 'su clic scegliere caratteri 0 a 5 di #note', conf: 0.5555555555555556 },
+  { lang: 'ja', src: '#note の 文字 0 から 5 を クリック で 選択', conf: 0.75, verbFinal: true },
+  { lang: 'ko', src: '#note 의 문자 0 부터 5 를 클릭 할 때 선택', conf: 0.75, verbFinal: true },
+  { lang: 'ms', src: 'apabila click pilih aksara 0 ke 5 daripada #note', conf: 0.5555555555555556 },
+  { lang: 'pl', src: 'na kliknięcie wybierz znaki 0 do 5 z #note', conf: 0.5555555555555556 },
+  { lang: 'pt', src: 'em clique escolher caracteres 0 a 5 de #note', conf: 0.5555555555555556 },
+  { lang: 'qu', src: '#note pa sanampa 0 kama 5 ta ñitiy pi akllay', conf: 0.75, verbFinal: true },
+  { lang: 'ru', src: 'при клик выбрать символы 0 в 5 из #note', conf: 0.5555555555555556 },
+  { lang: 'sw', src: 'kwenye bofya chagua herufi 0 hadi 5 ya #note', conf: 0.5555555555555556 },
+  { lang: 'th', src: 'เมื่อ คลิก เลือก อักขระ 0 ถึง 5 ของ #note', conf: 0.5555555555555556 },
+  { lang: 'tl', src: 'pumili karakter 0 sa 5 ng #note kapag click', conf: 0.75 },
+  {
+    lang: 'tr',
+    src: '#note nin karakterler 0 ile 5 i tıklama de seç',
+    conf: 0.75,
+    verbFinal: true,
+  },
+  { lang: 'uk', src: 'при клік вибрати символи 0 в 5 з #note', conf: 0.5555555555555556 },
+  { lang: 'vi', src: 'khi nhấp chọn ký tự 0 đến 5 của #note', conf: 0.5555555555555556 },
+  { lang: 'zh', src: '当 点击 时 选取 把 字符 0 到 5 的 #note', conf: 1 },
+];
+
+const ROWS = CORPUS.map(r => [r.lang, r.src] as [string, string]);
+
+describe('the en reference this row is scored against', () => {
+  it('types the unit word as an expression, via the identifier path', () => {
+    const pick = pickNode(EN_ROW, 'en');
+    expect(roleType(pick, 'method')).toBe('expression');
+    expect(roleSurface(pick, 'method')).toBe('characters');
+    expect(roleSurface(pick, 'patient')).toBe('0 to 5');
+    expect(roleSurface(pick, 'source')).toBe('#note');
+    expect(parseSemantic(EN_ROW, 'en').confidence).toBe(1);
+  });
+
+  it('leaves pickSchema untouched — pick extends via patterns, never the schema', () => {
+    const schema = getSchema('pick');
+    expect(schema?.roles.map(r => r.role)).toEqual(['patient', 'source']);
+    expect(schema?.roles.some(r => r.role === 'method')).toBe(false);
+  });
+});
+
+describe('every language agrees with the en role signature', () => {
+  const EN_SIGNATURE = roleSignature(parse(EN_ROW, 'en'));
+
+  it('the en signature is the one the harness compares against', () => {
+    expect(EN_SIGNATURE).toEqual([
+      'on.event:literal',
+      'pick.method:expression',
+      'pick.patient:expression',
+      'pick.source:selector',
+    ]);
+  });
+
+  it.each(ROWS)('%s matches it exactly', (lang, src) => {
+    expect(roleSignature(parse(src, lang))).toEqual(EN_SIGNATURE);
+  });
+
+  // The mutation row for change A: without the transform the unit word is a
+  // keyword-built literal in every one of these languages.
+  it.each(ROWS)('%s types the unit word as an expression', (lang, src) => {
+    const pick = pickNode(src, lang);
+    expect(roleType(pick, 'method')).toBe('expression');
+    expect(roleSurface(pick, 'method')).toBe('characters');
+  });
+
+  it.each(ROWS)('%s keeps the range and root intact', (lang, src) => {
+    const pick = pickNode(src, lang);
+    expect(roleSurface(pick, 'patient')).toBe('0 to 5');
+    expect(roleSurface(pick, 'source')).toBe('#note');
+  });
+});
+
+describe('the round trip survives the re-typing', () => {
+  // The mutation row for change B. With A applied but the preservation clause
+  // still type-checking, the fused re-parse swap is vetoed for the 13
+  // verb-initial languages and their handler bodies truncate to
+  // `on click pick characters`.
+  it.each(ROWS)('%s renders back to the canonical English', (lang, src) => {
+    const node = parse(src, lang);
+    expect(node).not.toBeNull();
+    expect(render(node as never, 'en')).toBe(EN_ROW);
+  });
+
+  it.each(ROWS)('%s keeps its adoption confidence (transform is post-scoring)', (lang, src) => {
+    const expected = CORPUS.find(r => r.lang === lang)!.conf;
+    const result = parseSemantic(src, lang);
+    expect(result.node).not.toBeNull();
+    expect(result.confidence).toBeCloseTo(expected, 10);
+  });
+});
+
+describe('the re-typing is scoped to unit words', () => {
+  // `first`/`last`/`random` ride the same `method` slot and ARE keywords in en,
+  // so both sides already agree on `literal`. Re-typing them would manufacture
+  // the inverse divergence.
+  it('en count variants stay literal', () => {
+    const pick = pickNode('pick first 3 of arr', 'en');
+    expect(roleType(pick, 'method')).toBe('literal');
+    expect(roleSurface(pick, 'method')).toBe('first');
+  });
+
+  it('foreign count variants stay literal too', () => {
+    const pick = pickNode('escoger primero 3 de arr', 'es');
+    expect(roleType(pick, 'method')).toBe('literal');
+    expect(roleSurface(pick, 'method')).toBe('first');
+  });
+});

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-08-01T13:49:56.045Z",
-  "commit": "c4185cf9",
+  "timestamp": "2026-08-01T14:05:47.307Z",
+  "commit": "1ea99eaf",
   "languages": {
     "ar": {
       "parseSuccess": 155,
@@ -10,14 +10,14 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9987012987012988,
+      "avgRoleFidelity": 1,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range"],
-      "bundleSize": 557658,
+      "roleLossyPatterns": [],
+      "bundleSize": 557709,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -649,14 +649,14 @@
       "avgFidelity": 1,
       "avgPrecision": 0.9978494623655915,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9974025974025975,
+      "avgRoleFidelity": 0.9987012987012988,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range", "take-class-from-siblings"],
-      "bundleSize": 557658,
+      "roleLossyPatterns": ["take-class-from-siblings"],
+      "bundleSize": 557709,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1288,14 +1288,14 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9987012987012988,
+      "avgRoleFidelity": 1,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range"],
-      "bundleSize": 557658,
+      "roleLossyPatterns": [],
+      "bundleSize": 557709,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1924,7 +1924,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 557658,
+      "bundleSize": 557709,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2556,14 +2556,14 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9987012987012988,
+      "avgRoleFidelity": 1,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range"],
-      "bundleSize": 557658,
+      "roleLossyPatterns": [],
+      "bundleSize": 557709,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3195,14 +3195,14 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9987012987012988,
+      "avgRoleFidelity": 1,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range"],
-      "bundleSize": 557658,
+      "roleLossyPatterns": [],
+      "bundleSize": 557709,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3834,14 +3834,14 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9970779220779221,
+      "avgRoleFidelity": 0.9983766233766234,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range", "set-attribute"],
-      "bundleSize": 557658,
+      "roleLossyPatterns": ["set-attribute"],
+      "bundleSize": 557709,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4473,14 +4473,14 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9974025974025975,
+      "avgRoleFidelity": 0.9987012987012988,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range", "take-class-from-siblings"],
-      "bundleSize": 557658,
+      "roleLossyPatterns": ["take-class-from-siblings"],
+      "bundleSize": 557709,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5112,19 +5112,14 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9957637600494745,
+      "avgRoleFidelity": 0.9970624613481758,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "fetch-do-not-throw",
-        "fetch-error-handling",
-        "fetch-json",
-        "pick-text-range"
-      ],
-      "bundleSize": 557658,
+      "roleLossyPatterns": ["fetch-do-not-throw", "fetch-error-handling", "fetch-json"],
+      "bundleSize": 557709,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5756,14 +5751,14 @@
       "avgFidelity": 1,
       "avgPrecision": 0.9978494623655915,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9974025974025975,
+      "avgRoleFidelity": 0.9987012987012988,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range", "take-class-from-siblings"],
-      "bundleSize": 557658,
+      "roleLossyPatterns": ["take-class-from-siblings"],
+      "bundleSize": 557709,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6395,14 +6390,14 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9974025974025975,
+      "avgRoleFidelity": 0.9987012987012988,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range", "take-class-from-siblings"],
-      "bundleSize": 557658,
+      "roleLossyPatterns": ["take-class-from-siblings"],
+      "bundleSize": 557709,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7034,19 +7029,18 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9941558441558443,
+      "avgRoleFidelity": 0.9954545454545455,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [
-        "pick-text-range",
         "take-class-from-siblings",
         "when-multiple-changes",
         "when-value-changes"
       ],
-      "bundleSize": 557658,
+      "bundleSize": 557709,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7678,14 +7672,14 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9965367965367967,
+      "avgRoleFidelity": 0.997835497835498,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["hide-with-transition", "pick-text-range"],
-      "bundleSize": 557658,
+      "roleLossyPatterns": ["hide-with-transition"],
+      "bundleSize": 557709,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8317,14 +8311,14 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9974025974025975,
+      "avgRoleFidelity": 0.9987012987012988,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range", "unless-condition"],
-      "bundleSize": 557658,
+      "roleLossyPatterns": ["unless-condition"],
+      "bundleSize": 557709,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8956,14 +8950,14 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9987012987012988,
+      "avgRoleFidelity": 1,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range"],
-      "bundleSize": 557658,
+      "roleLossyPatterns": [],
+      "bundleSize": 557709,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9595,7 +9589,7 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9948515769944343,
+      "avgRoleFidelity": 0.9961502782931355,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
@@ -9604,10 +9598,9 @@
       "roleLossyPatterns": [
         "announce-screen-reader",
         "on-custom-event-receive",
-        "pick-text-range",
         "take-class-from-siblings"
       ],
-      "bundleSize": 557658,
+      "bundleSize": 557709,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10239,14 +10232,14 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9974025974025975,
+      "avgRoleFidelity": 0.9987012987012988,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range", "take-class-from-siblings"],
-      "bundleSize": 557658,
+      "roleLossyPatterns": ["take-class-from-siblings"],
+      "bundleSize": 557709,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10878,14 +10871,14 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9987012987012988,
+      "avgRoleFidelity": 1,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range"],
-      "bundleSize": 557658,
+      "roleLossyPatterns": [],
+      "bundleSize": 557709,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11517,14 +11510,14 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9974025974025975,
+      "avgRoleFidelity": 0.9987012987012988,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range", "toggle-aria-expanded"],
-      "bundleSize": 557658,
+      "roleLossyPatterns": ["toggle-aria-expanded"],
+      "bundleSize": 557709,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12156,14 +12149,14 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9987012987012988,
+      "avgRoleFidelity": 1,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range"],
-      "bundleSize": 557658,
+      "roleLossyPatterns": [],
+      "bundleSize": 557709,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12795,14 +12788,14 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9974025974025975,
+      "avgRoleFidelity": 0.9987012987012988,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range", "take-class-from-siblings"],
-      "bundleSize": 557658,
+      "roleLossyPatterns": ["take-class-from-siblings"],
+      "bundleSize": 557709,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13434,14 +13427,14 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9974025974025975,
+      "avgRoleFidelity": 0.9987012987012988,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range", "take-class-from-siblings"],
-      "bundleSize": 557658,
+      "roleLossyPatterns": ["take-class-from-siblings"],
+      "bundleSize": 557709,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14073,18 +14066,14 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9961038961038964,
+      "avgRoleFidelity": 0.9974025974025975,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "its-value-possessive-dot",
-        "pick-text-range",
-        "take-class-from-siblings"
-      ],
-      "bundleSize": 557658,
+      "roleLossyPatterns": ["its-value-possessive-dot", "take-class-from-siblings"],
+      "bundleSize": 557709,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14716,14 +14705,14 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9966914038342611,
+      "avgRoleFidelity": 0.9979901051329624,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": ["pick-text-range", "repeat-forever", "repeat-until-event"],
-      "bundleSize": 557658,
+      "roleLossyPatterns": ["repeat-forever", "repeat-until-event"],
+      "bundleSize": 557709,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15350,7 +15339,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 557658,
+      "size": 557709,
       "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }


### PR DESCRIPTION
## Headline: the standing deferral's premise was stale

`pick-text-range` was the largest cluster in the R1 burn-down tail — **23 rows,
44% of it** — and `MULTILINGUAL_NEXT_STEPS.md` described it as the most
expensive item in the queue:

> the en reference itself is degenerate (`pick.patient:expression="characters"`
> — the first WORD; pickSchema models no range/source roles) … The proper fix
> (pickSchema range roles + transformer render + SOV pattern variants) RAISES
> the en denominator for all 24 languages … budget the full 24-language
> realignment.

**All of that already shipped**, on 2026-07-20, as pick-text-range arcs 1–3
(#733 / #734 / #736). Both canonical-validity allowlists are empty and all 24
corpus rows already round-trip to byte-identical English
(`pick-command.test.ts:145-186`). The 23 R1 rows were not the deferred
realignment; they were a residue `roleLossyPatterns` (added by #856) simply
made visible for the first time.

## The actual defect: one valueType, 23 languages

`--triage-r1` reports the same single entry in every non-en language:

```
missing  pick.method:expression      (the en reference)
captured pick.method:literal         (all 23 foreign parses)
```

Every role present, right slot, right value — only the type differs, because
the two sides reach `method` down different token paths:

| side | path | result |
| --- | --- | --- |
| en | `characters` is deliberately NOT an en keyword (`en/pick.ts:70-74`: keywording it "would only risk this pattern's identifier path") | identifier branch → `{type:'expression'}` |
| 23 foreign | `characters` IS a tokenizer keyword in all 22 foreign tokenizers | keyword branch → `createLiteral()` |

R1 compares `action.role:valueType`, so that asymmetry alone read as a dropped
role — and for **ar/es/pt/sw/tl it was their only R1 miss in the whole corpus**.

## The fix — two halves, both required

**A. `patterns/pick.ts`** re-types unit-word captures on the `method` slot of
both factories (verb-initial + SOV verb-final) through the existing
`ExtractionRule.transform` hook — the field's second consumer after the qu
`go-url-dest` fix. `applyExtractionRules` runs **after** the confidence model
(`pattern-matcher.ts` line 119 vs 110), so no adoption decision can move; every
per-language confidence is pinned unchanged in the test.

Conditional on the unit words only. `first`/`last`/`random` ride the same slot
and **are** keywords in en, so re-typing them would manufacture the inverse
divergence — pinned by a guard row.

**B. the pick preservation clause** in `semantic-parser.ts` now compares the
re-parsed `method` by **surface** rather than by type. It required `literal`;
with A applied that veto killed the fused re-parse swap and truncated the
handler body to `on click pick characters` — the arc-3 canonical-validity
cluster, re-opened. Keeping the literal arm makes it a strict widening.

`pickSchema` stays byte-identical, as its header demands (pick extends via
patterns, never the schema). That rules out the third option — registering
`characters` in `ENGLISH_EXTRAS` — which the en pattern explicitly warns
against and which would move the en reference for all 24 languages.

## Measured, not argued

A **whole-corpus pre/post probe** over all **3960** stored patterns.db rows (24
languages × the full pattern set) diffs to **exactly the 23 `pick-text-range`
rows**, all one shape, and nothing else:

```
23 ×  S=[…|pick.method:literal|…]  =>  S=[…|pick.method:expression|…]
```

**Both halves independently mutation-verified.** Reverting A reddens the
signature and method-type rows in all 23 languages. Reverting B alone (A in
place) reddens **13** — de/es/fr/id/it/ms/pl/pt/ru/sw/th/uk/vi, the languages
whose corpus row routes through the fused body-walk swap — including their
round-trip rows, i.e. the truncation. The SOV six and ar/he/tl/zh never reach
that swap, which is why B alone proves nothing without A.

## Test lock

`packages/semantic/test/pick-method-role-fidelity.test.ts` (120 assertions).
All 23 corpus surfaces verbatim from a freshly `populate`d DB, each with its
measured `parseSemantic` confidence pinned. A local `roleSignature()` mirrors
the harness's `collectRoleSignature` (duplicated deliberately — no
cross-package test dependency) and asserts every language matches the en
signature exactly. Plus: the range/root stay intact, all 23 round-trip to the
canonical English, `pickSchema` is asserted frozen at `[patient, source]`, and
count variants stay `literal` in both en and es.

## Baseline diff

All 23 non-en languages drop `pick-text-range` from `roleLossyPatterns`;
`avgRoleFidelity` +0.0013 each. **Seven languages now sit at 1.0000 — ar, de,
es, fr, pt, sw, tl are fully role-faithful** (de/fr via #867). No parse-rate,
R0, precision, multiset-recall, value-recall, R2, R4 or R5 movement.

**With #867, the R1 tail goes 52 → 24 rows**: the 10 `take.recipient`
deferrals (#864's named i18n-rendering follow-up) and 14 scattered singletons.

## Gates

Multilingual `--regression` green · `test:canonical` 7/7, both allowlists still
**EMPTY** · semantic 7502 tests / 113 files · root `test:check` 39 packages
incl. vocab consistency (0 unwaived), hyperscript-adapter syntax-table, and the
R2 subset lock · `npm run lint` clean.

Parser/pattern change only — no schema, profile, dict or tokenizer edit — so no
syntax-table regen, vocab waiver, `docs:commands` restage, or domain-voice
review applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
