### PR TITLE
fix(core): stop publishing isBlocking/hasBody/version — 59 commands asserted things no author claimed

### DIFF
--- a/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
+++ b/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
@@ -699,36 +699,86 @@ not the core abstractions.
     the whole episode because the pattern was not in it. Detail:
     `MULTILINGUAL_NEXT_STEPS.md` § "R3-discovered value-bug families" item 6.
 
-- **`command-adapter.ts` declares its own `CommandMetadata`, and the load-bearing
-  reader uses it.** `:54-60` defines a loose shape with an
-  `[extra: string]: unknown` index signature — which is the only reason
-  `impl.metadata?.name` at `:421` typechecks, since the canonical
-  `types/command-metadata.ts` interface has **no `name` field**. Narrowing the
-  adapter to the canonical type turns `:421` into a type error, and `readonly` vs
-  mutable arrays will bite as well. Contained to one file (the shadow type is
-  exported but imported by nobody). It is a **behavior** question — that fallback
-  is the only path for a V1 command carrying `metadata.name` — so it wants its own
-  change rather than a slot inside a refactor. Third instance of the
-  dual-type-definition pattern (see also `ASTNode`/`ExpressionMetadata`). Detail:
+- ~~**`command-adapter.ts` declares its own `CommandMetadata`, and the load-bearing
+  reader uses it.**~~ **CLOSED 2026-08-01 — measured, and three of its four claims
+  are false.** The experiment (replace the shadow type with the canonical one,
+  typecheck) produces 9 errors, and none of them is the one filed:
+
+  - **`:421` does NOT error.** Its enclosing signature is `register(impl: any)`,
+    so the parameter's `any` — not the index signature — is what defeats
+    checking there. Narrowing the interface changes nothing about that line.
+    The sites that do error are `:207` (the `get name()` getter) and `:211`
+    (the `get metadata()` projection no longer satisfies `RuntimeCommand`).
+  - **The blast radius is not one file.** 7 of the 9 errors land in
+    `registry/examples/server-commands.ts` and `registry/multilingual/examples.ts`,
+    which declare `category: 'server'` — absent from the canonical union. That is
+    the F-B2 union reconciliation, deliberately pinned as "a rename with LSP and
+    docs reach".
+  - **The behavior question is vacuous in-tree.** All 55 command classes (52
+    decorated via `@command({name})`, plus `install`/`pseudo-command`/`render`
+    carrying `readonly name = '…'`) have a top-level `name`, so the
+    `metadata.name` fallback is dead for everything that ships. It is a public-API
+    affordance for third-party V1 registration only — and it IS covered, by
+    `runtime.test.ts`'s "should accept commands with metadata.name".
+
+  Not worth paying a union reconciliation to fix a hole that is not where the
+  filing put it. **What the experiment DID find is bigger and is filed fresh
+  below.**
+
+- **`CommandWithParseInput` describes no real command, and `register(impl: any)`
+  is what hides it.** (Opened 2026-08-01, out of the F-B1 measurement.) The
+  registry's own private map is `Map<string, CommandWithParseInput>`
+  (`command-adapter.ts:380`), and `COMMAND_FACTORIES` is
+  `Readonly<Record<string, () => unknown>>` (`runtime.ts:137`) — so the
+  manifest-driven registration of all 59 commands is unchecked end to end.
+  Typing either one produces **59 errors, all the same**:
+
+  ```text
+  The types returned by 'validate(...)' are incompatible between these types.
+    Type 'boolean' is not assignable to type 'ValidationResult<unknown>'.
+  ```
+
+  The interface declares `validate?(input): ValidationResult<unknown>`; every
+  real command implements `validate(input): input is XInput`, a type guard
+  returning **boolean**. So `CommandAdapterV2.validate()` (`:361`) would return a
+  boolean while its signature promises `{isValid, errors, suggestions}`. It has
+  never bitten because the only consumer, `CommandRegistryV2.validateCommand()`
+  (`:489`), is **called by nobody** (the `validateCommand` hits elsewhere are
+  `CommandPatternValidator`'s unrelated static).
+
+  So this is a latent whole-registry contract lie, currently unreachable. The
+  fix is an owner decision — is `validate` a type guard or a structured
+  validator? — and then either one interface line or 59 command signatures.
+  Do NOT "fix" it by widening the interface to `boolean | ValidationResult`;
+  that preserves the ambiguity that let the two drift. Third instance of the
+  dual-type-definition pattern (see also `ASTNode`/`ExpressionMetadata`).
+  Historical detail on the shadow type:
   [HANDOFF-command-arch-metadata.md](./HANDOFF-command-arch-metadata.md) § F-B1.
 
-- **`metadata.isBlocking` / `hasBody` publish false claims for ≥7 commands.**
-  Neither field is authored anywhere — every value comes from `@meta`'s (now
-  `commandMeta`'s) `?? false` default — and nothing in production reads them. But
-  they ARE published: `packages/core/docs/commands/commands.json` carries
-  `isBlocking: false`, `hasBody: false`, `version: '1.0.0'` on 40 of its 43
-  entries, with **zero variance**. So the shipped docs state that `wait`, `fetch`,
-  `settle` and `transition` do not block, and that `if`, `repeat` and `tell` take
-  no body. All false.
-  Arc B step 3 deliberately PRESERVED the boilerplate rather than fixing or
-  deleting it, to keep the migration a refactor (decision recorded in
-  [HANDOFF-command-arch-metadata.md](./HANDOFF-command-arch-metadata.md)).
-  Authoring the two booleans truthfully is ~59 judgment calls with its own review
-  surface, and `version` is meaningless per-command — worth its own change.
-  Note there may be derivable sources: `COMPOUND_COMMANDS` and the parser's
-  `CommandNode.isBlocking` already encode part of this, so check before hand-
-  authoring 59 rows. Discovered by Arc B while measuring what should happen to
-  `@meta`'s defaults — the queue's "score the rows already there" lesson again.
+- ~~**`metadata.isBlocking` / `hasBody` publish false claims for ≥7 commands.**~~
+  **FIXED 2026-08-01 — by deleting the fields, not by authoring them.** By the
+  time it was taken the uniformity had spread from 40/43 to **59/59**: every
+  command published `isBlocking: false`, `hasBody: false`, `version: '1.0.0'`,
+  asserting that `wait`/`fetch`/`settle`/`transition` do not block and that
+  `if`/`repeat`/`tell` take no body.
+  The filing framed the fix as ~59 judgment calls. Measured, that is the wrong
+  end. The fields are **unauthored, unread, and unrendered** — no command literal
+  sets them, nothing in production reads them, `REFERENCE.md` does not render
+  them (it is byte-identical after the change), no gate pinned them, and
+  `commands.json` is not even in `package.json`'s `files`, so it never shipped to
+  npm. **Defaulting them was the entire source of the falsehood**, so
+  `commandMeta()` no longer defaults anything and the three keys are gone from
+  all 59 JSON rows (a pure 177-line deletion).
+  They stay OPTIONAL on `CommandMetadata`, and absence now means UNDECLARED
+  rather than `false` — so a future truthful declaration carries meaning. Guarded
+  by a registry-wide row in `command-meta.test.ts` that fails if any of the three
+  reappears on *every* command (the signature of the default returning);
+  mutation-verified. If a consumer ever appears, prefer deriving:
+  `COMPOUND_COMMANDS` and the parser's `CommandNode.isBlocking` already encode
+  much of it. Original discovery credit: Arc B, while measuring what should
+  happen to `@meta`'s defaults — the queue's "score the rows already there"
+  lesson, and the follow-up is its sequel: **score the FIX the filing proposes,
+  too.**
 
 ## Risk register
 

--- a/docs-internal/HANDOFF-command-arch-metadata.md
+++ b/docs-internal/HANDOFF-command-arch-metadata.md
@@ -180,6 +180,29 @@ The four shared-implementation groups:
 
 ### F-B1 — there are TWO `CommandMetadata` interfaces, and the load-bearing reader uses the loose one
 
+> **CLOSED 2026-08-01. Read the correction below before acting on anything in
+> this section.** The experiment this section asks for was run (swap the shadow
+> type for the canonical one, typecheck) and it falsifies three of the four
+> claims:
+>
+> - **`:421` does not error.** Its signature is `register(impl: any)` — the
+>   parameter's `any`, not the index signature, is what defeats checking there.
+>   The erroring sites are `:207` and `:211`.
+> - **Not contained to one file.** 7 of the 9 errors are in
+>   `registry/examples/server-commands.ts` + `registry/multilingual/examples.ts`
+>   (`category: 'server'`, absent from the canonical union) — i.e. it drags in
+>   F-B2, which is deliberately pinned.
+> - **The behavior question is vacuous in-tree.** All 55 command classes carry a
+>   top-level `name`, so the `metadata.name` fallback is dead for everything
+>   that ships (it is exercised only by `runtime.test.ts`'s third-party-shape
+>   test).
+>
+> What the experiment DID find is larger and is filed fresh in
+> COMMAND_ARCHITECTURE_NEXT_STEPS.md: `CommandWithParseInput` declares
+> `validate?(): ValidationResult<unknown>` while all 59 commands implement a
+> boolean type guard, and `register(impl: any)` + `COMMAND_FACTORIES: () => unknown`
+> are what hide it. Latent (nothing calls `validateCommand()`), owner decision.
+
 `command-adapter.ts:54-60` declares its **own** `CommandMetadata`:
 
 ```ts
@@ -691,12 +714,13 @@ It guards the thing `commandMeta` structurally cannot — `''` is a perfectly go
 `string`, so the type system will never object to an empty description, while the
 generator will happily publish it.
 
-**Still open from F-B1, deliberately not folded in:** narrowing
+~~**Still open from F-B1, deliberately not folded in:** narrowing
 `command-adapter.ts`'s shadow `CommandMetadata` and settling `:421`'s name
-fallback. It is a behavior question (the fallback is the only path for a V1
-command carrying `metadata.name`, and the canonical type has no `name` field), not
-a docs one, so it does not belong in the same PR as a docs generator. Recorded in
-the queue.
+fallback.~~ **CLOSED 2026-08-01 — see the correction banner at § F-B1.** `:421`
+does not depend on the shadow type at all (`register(impl: any)`), the narrowing
+drags in the pinned F-B2 union, and the fallback is dead for every command that
+ships. The real defect the measurement surfaced — `CommandWithParseInput`'s
+`validate` signature matching none of the 59 commands — is filed in the queue.
 
 ## Gate couplings that must move in the same diff
 

--- a/packages/core/docs/commands/commands.json
+++ b/packages/core/docs/commands/commands.json
@@ -67,9 +67,6 @@
   ],
   "commands": {
     "add": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Add CSS classes, attributes, or styles to elements",
       "syntax": ["add <classes|@attr|{styles}> [to <target>]"],
       "examples": [
@@ -83,9 +80,6 @@
       "compatibility": "standard"
     },
     "append": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Add content to the end of a string, array, Set, or HTML element",
       "syntax": ["append <content>", "append <content> to <target>"],
       "examples": [
@@ -100,9 +94,6 @@
       "compatibility": "standard"
     },
     "async": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Execute commands asynchronously without blocking",
       "syntax": ["async <command> [<command> ...]"],
       "examples": [
@@ -115,9 +106,6 @@
       "compatibility": "lokascript-extension"
     },
     "beep": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Debug output for expressions with type information",
       "syntax": ["beep!", "beep! <expression>", "beep! <expression>, <expression>, ..."],
       "examples": ["beep!", "beep! myValue", "beep! me.id, me.className"],
@@ -126,9 +114,6 @@
       "compatibility": "lokascript-extension"
     },
     "blur": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Remove focus from an element (calls HTMLElement.blur())",
       "syntax": ["blur", "blur <target>", "blur on <target>"],
       "examples": ["blur", "blur #search", "blur on <input/>"],
@@ -137,9 +122,6 @@
       "compatibility": "standard"
     },
     "break": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Exit from the current loop (repeat, for, while, until)",
       "syntax": ["break"],
       "examples": [
@@ -152,9 +134,6 @@
       "compatibility": "standard"
     },
     "breakpoint": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Drop into the debugger (emits a debugger; statement)",
       "syntax": ["breakpoint"],
       "examples": ["breakpoint", "on click breakpoint"],
@@ -163,9 +142,6 @@
       "compatibility": "standard"
     },
     "call": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Evaluate an expression and store the result in the it variable",
       "syntax": ["call <expression>"],
       "examples": ["call myFunction()", "call fetch(\"/api/data\")", "call element.focus()"],
@@ -174,9 +150,6 @@
       "compatibility": "standard"
     },
     "clear": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Reset a variable to null or clear the value of a form field (<input>, <textarea>, <select>)",
       "syntax": ["clear <var>", "clear :var", "clear <target>"],
       "examples": ["clear :count", "clear myVar", "clear #search", "clear <textarea/>"],
@@ -185,9 +158,6 @@
       "compatibility": "standard"
     },
     "close": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Close a dialog, details element, or popover",
       "syntax": ["close", "close <target>"],
       "examples": ["close", "close #myDialog", "close #details", "close #popup"],
@@ -196,9 +166,6 @@
       "compatibility": "standard"
     },
     "continue": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Skip to the next iteration of the current loop",
       "syntax": ["continue"],
       "examples": [
@@ -211,9 +178,6 @@
       "compatibility": "standard"
     },
     "copy": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Copy text or element content to the clipboard",
       "syntax": ["copy <source>", "copy <source> to clipboard"],
       "examples": ["copy \"Hello World\"", "copy #code-snippet", "copy my textContent"],
@@ -222,9 +186,6 @@
       "compatibility": "lokascript-extension"
     },
     "decrement": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Modify a variable or property by a specified amount (default: 1)",
       "syntax": ["increment <target> [by <number>]", "decrement <target> [by <number>]"],
       "examples": [
@@ -239,9 +200,6 @@
       "compatibility": "standard"
     },
     "default": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Set a value only if it doesn't already exist",
       "syntax": ["default <expression> to <expression>"],
       "examples": [
@@ -254,9 +212,6 @@
       "compatibility": "standard"
     },
     "empty": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Remove all children from an element (sets innerHTML to empty)",
       "syntax": ["empty", "empty <target>", "empty the <target>"],
       "examples": ["empty me", "empty #list", "empty .results"],
@@ -265,9 +220,6 @@
       "compatibility": "standard"
     },
     "exit": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Immediately terminate execution of the current event handler or behavior",
       "syntax": ["exit"],
       "examples": ["exit", "if no draggedItem exit", "on click if disabled exit"],
@@ -276,9 +228,6 @@
       "compatibility": "standard"
     },
     "fetch": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Make HTTP requests with lifecycle event support",
       "syntax": ["fetch <url>", "fetch <url> as <type>", "fetch <url> with <options>"],
       "examples": [
@@ -291,9 +240,6 @@
       "compatibility": "standard"
     },
     "focus": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Focus an element (calls HTMLElement.focus())",
       "syntax": ["focus", "focus <target>", "focus on <target>"],
       "examples": ["focus", "focus #search", "focus on <input/>"],
@@ -302,9 +248,6 @@
       "compatibility": "standard"
     },
     "get": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Evaluate an expression and store the result in it",
       "syntax": ["get <expression>"],
       "examples": ["get #my-dialog", "get <button/>", "get me.parentElement"],
@@ -313,9 +256,6 @@
       "compatibility": "standard"
     },
     "go": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Navigation functionality including URL navigation, element scrolling, and browser history",
       "syntax": ["go back", "go to url <url> [in new window]", "go to [position] [of] <element>"],
       "examples": ["go back", "go to url \"https://example.com\"", "go to top of #header"],
@@ -324,9 +264,6 @@
       "compatibility": "standard"
     },
     "halt": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Stop command execution or prevent event defaults",
       "syntax": ["halt", "halt the event"],
       "examples": [
@@ -340,9 +277,6 @@
       "compatibility": "standard"
     },
     "hide": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Hide elements by setting display to none",
       "syntax": ["hide [<target>]"],
       "examples": ["hide me", "hide #modal", "hide .warnings", "hide <button/>"],
@@ -351,9 +285,6 @@
       "compatibility": "standard"
     },
     "if": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Conditional execution based on boolean expressions",
       "syntax": [
         "if <condition> then <commands>",
@@ -371,9 +302,6 @@
       "compatibility": "standard"
     },
     "increment": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Modify a variable or property by a specified amount (default: 1)",
       "syntax": ["increment <target> [by <number>]", "decrement <target> [by <number>]"],
       "examples": [
@@ -388,9 +316,6 @@
       "compatibility": "standard"
     },
     "install": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Install a behavior on an element with optional parameters",
       "syntax": [
         "install <BehaviorName>",
@@ -410,9 +335,6 @@
       "sideEffects": ["behavior-installation", "element-modification"]
     },
     "js": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Execute inline JavaScript code with access to hyperscript context",
       "syntax": ["js <code> end", "js(param1, param2) <code> end"],
       "examples": [
@@ -425,9 +347,6 @@
       "compatibility": "standard"
     },
     "log": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Log values to the console",
       "syntax": ["log [<values...>]"],
       "examples": ["log \"Hello World\"", "log me.value", "log x y z", "log \"Result:\" result"],
@@ -436,9 +355,6 @@
       "compatibility": "standard"
     },
     "make": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Create DOM elements or class instances",
       "syntax": [
         "make a <tag#id.class1.class2/>",
@@ -453,9 +369,6 @@
       "compatibility": "standard"
     },
     "measure": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Measure DOM element dimensions, positions, and properties",
       "syntax": ["measure", "measure <property>", "measure <target> <property>"],
       "examples": [
@@ -469,9 +382,6 @@
       "compatibility": "standard"
     },
     "morph": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Morph content into target elements (intelligent diffing, preserves state)",
       "syntax": ["morph <target> with <content>", "morph over <target> with <content>"],
       "examples": ["morph #target with it", "morph over #modal with fetchedContent"],
@@ -480,9 +390,6 @@
       "compatibility": "standard"
     },
     "open": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Open a dialog, details element, or popover",
       "syntax": ["open [<target>]", "open <dialog> as modal", "open <dialog> as non-modal"],
       "examples": ["open", "open #myDialog", "open #details", "open #popup as non-modal"],
@@ -491,9 +398,6 @@
       "compatibility": "standard"
     },
     "pick": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Select from a collection (first/last/random/range/regex match)",
       "syntax": [
         "pick first <count> of <expr>",
@@ -518,9 +422,6 @@
       "compatibility": "standard"
     },
     "prepend": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Add content to the start of a string, array, Set, or HTML element",
       "syntax": ["prepend <content>", "prepend <content> to <target>"],
       "examples": [
@@ -534,9 +435,6 @@
       "compatibility": "lokascript-extension"
     },
     "process": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Process <hx-partial> elements for multi-target swaps",
       "syntax": [
         "process partials in <content>",
@@ -552,9 +450,6 @@
       "compatibility": "lokascript-extension"
     },
     "pseudo-command": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Treat a method on an object as a top-level command",
       "syntax": ["<method>(<args>) [(to|on|with|into|from|at)] <expression>"],
       "examples": [
@@ -568,9 +463,6 @@
       "sideEffects": ["method-execution"]
     },
     "push": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Modify browser history URL without page reload",
       "syntax": [
         "push url <url>",
@@ -590,9 +482,6 @@
       "compatibility": "lokascript-extension"
     },
     "put": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Insert content into elements or properties",
       "syntax": [
         "put <value> into <target>",
@@ -609,9 +498,6 @@
       "compatibility": "standard"
     },
     "remove": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Remove CSS classes, attributes, styles, or elements from the DOM",
       "syntax": ["remove <classes|@attr|*prop|element> [from <target>]"],
       "examples": [
@@ -626,9 +512,6 @@
       "compatibility": "standard"
     },
     "render": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Render templates with @if, @else, and @repeat directives",
       "syntax": [
         "render <template>",
@@ -646,9 +529,6 @@
       "sideEffects": ["dom-creation", "template-execution"]
     },
     "repeat": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Iteration in hyperscript - for-in, counted, conditional, event-driven, and infinite loops",
       "syntax": [
         "repeat for <var> in <collection> { <commands> }",
@@ -663,9 +543,6 @@
       "compatibility": "standard"
     },
     "replace": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Modify browser history URL without page reload",
       "syntax": [
         "push url <url>",
@@ -685,9 +562,6 @@
       "compatibility": "lokascript-extension"
     },
     "reset": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Reset a <form> element to its default values (HTMLFormElement.reset())",
       "syntax": ["reset", "reset <target>"],
       "examples": ["reset", "reset #myForm", "reset <form/>"],
@@ -696,9 +570,6 @@
       "compatibility": "standard"
     },
     "return": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Return a value from a command sequence or function, terminating execution",
       "syntax": ["return", "return <value>"],
       "examples": ["return", "return 42", "return user.name", "if found then return result"],
@@ -707,9 +578,6 @@
       "compatibility": "standard"
     },
     "scroll": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Scroll an element into view (upstream _hyperscript 0.9.90)",
       "syntax": ["scroll to <target>", "scroll to top of <target>", "scroll to <target> smoothly"],
       "examples": ["scroll to #top", "scroll to bottom of #chat", "scroll to me smoothly"],
@@ -718,9 +586,6 @@
       "compatibility": "standard"
     },
     "select": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Select the contents of a text field, or select the contents of a DOM element",
       "syntax": ["select", "select <target>"],
       "examples": ["select #search", "select <textarea/>", "select me"],
@@ -729,9 +594,6 @@
       "compatibility": "standard"
     },
     "send": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Dispatch events on elements",
       "syntax": [
         "trigger <event> on <target>",
@@ -751,9 +613,6 @@
       "compatibility": "standard"
     },
     "set": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Set values to variables, attributes, or properties",
       "syntax": ["set <target> to <value>"],
       "examples": [
@@ -766,9 +625,6 @@
       "compatibility": "standard"
     },
     "settle": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Wait for CSS transitions and animations to complete",
       "syntax": ["settle [<target>] [for <timeout>]"],
       "examples": ["settle", "settle #animated-element", "settle for 3000"],
@@ -777,9 +633,6 @@
       "compatibility": "standard"
     },
     "show": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Show elements by restoring display property",
       "syntax": ["show [<target>]"],
       "examples": ["show me", "show #modal", "show .hidden", "show <button/>"],
@@ -788,9 +641,6 @@
       "compatibility": "standard"
     },
     "start": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Wrap a block of commands in document.startViewTransition()",
       "syntax": ["start view transition [using <type>] <body> end"],
       "examples": [
@@ -802,9 +652,6 @@
       "compatibility": "standard"
     },
     "swap": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Swap content into target elements with intelligent morphing support",
       "syntax": [
         "swap <target> with <content>",
@@ -825,9 +672,6 @@
       "compatibility": "standard"
     },
     "take": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Move classes, attributes, and properties from one element to another",
       "syntax": [
         "take <class> [from <source>] [for <recipient>]",
@@ -844,9 +688,6 @@
       "compatibility": "standard"
     },
     "tell": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Execute commands in the context of target elements",
       "syntax": ["tell <target> <command> [<command> ...]"],
       "examples": [
@@ -859,9 +700,6 @@
       "compatibility": "standard"
     },
     "throw": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Throw an error with a specified message",
       "syntax": ["throw <message>"],
       "examples": ["throw \"Invalid input\"", "if not valid then throw \"Validation failed\""],
@@ -870,9 +708,6 @@
       "compatibility": "standard"
     },
     "toggle": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Toggle classes, attributes, or interactive elements",
       "syntax": [
         "toggle <class> [on <target>]",
@@ -891,9 +726,6 @@
       "compatibility": "standard"
     },
     "transition": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Animate CSS properties using CSS transitions",
       "syntax": ["transition [<target>] <property> to <value> [over <duration>] [with <timing>]"],
       "examples": [
@@ -908,9 +740,6 @@
       "compatibility": "standard"
     },
     "trigger": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Dispatch events on elements",
       "syntax": [
         "trigger <event> on <target>",
@@ -930,9 +759,6 @@
       "compatibility": "standard"
     },
     "unless": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Conditional execution based on boolean expressions",
       "syntax": [
         "if <condition> then <commands>",
@@ -950,9 +776,6 @@
       "compatibility": "standard"
     },
     "wait": {
-      "isBlocking": false,
-      "hasBody": false,
-      "version": "1.0.0",
       "description": "Wait for time delay, event, or race condition",
       "syntax": ["wait <time>", "wait for <event>", "wait for <event> or <condition>"],
       "examples": [

--- a/packages/core/src/commands/decorators/__tests__/command-meta.test.ts
+++ b/packages/core/src/commands/decorators/__tests__/command-meta.test.ts
@@ -79,6 +79,38 @@ describe('the static/instance metadata bridge', () => {
       .map(([name]) => name);
     expect(missing).toEqual([]);
   });
+
+  it('publishes no UNAUTHORED isBlocking/hasBody/version on any command', () => {
+    // The gate against the defaults coming back. `commandMeta()` used to fill
+    // all three, so the generated `docs/commands/commands.json` carried
+    // `isBlocking: false`, `hasBody: false`, `version: '1.0.0'` on all 59
+    // commands with ZERO variance — asserting that `wait`, `fetch`, `settle`
+    // and `transition` do not block and that `if`, `repeat` and `tell` take no
+    // body. Nothing authored those values and nothing read them; the defaulting
+    // was the entire source of the falsehood.
+    //
+    // Absence is now meaningful (UNDECLARED, not `false`), so this checks for
+    // *unauthored* presence: a command may still declare one truthfully, but a
+    // uniform value across the whole registry is the defaulting bug returning.
+    // Written registry-wide rather than over CONVERTED because the defect was
+    // never about those three classes — it was about all of them.
+    const present: Record<string, string[]> = { isBlocking: [], hasBody: [], version: [] };
+    const total = registryImplementations().size;
+    for (const [name, impl] of registryImplementations()) {
+      const md = (impl.metadata ?? {}) as Record<string, unknown>;
+      for (const field of Object.keys(present)) {
+        if (field in md) present[field]!.push(name);
+      }
+    }
+    for (const [field, names] of Object.entries(present)) {
+      expect(
+        names.length,
+        `${field} is declared on ${names.length}/${total} commands. If that equals the ` +
+          `registry size, commandMeta() is defaulting it again — which publishes a claim ` +
+          `no author made. A few truthful declarations are fine; all of them is the bug.`
+      ).toBeLessThan(total);
+    }
+  });
 });
 
 describe('the classes converted to commandMeta() in step 1', () => {
@@ -93,25 +125,24 @@ describe('the classes converted to commandMeta() in step 1', () => {
     }
   );
 
-  it.each(CONVERTED)('$name now carries the three defaults (step 3 MOVED this row)', ({ cls }) => {
-    // INVERTED in step 3, deliberately, and left as an explicit assertion
-    // rather than deleted so the change reads as a moved row.
+  it.each(CONVERTED)('$name carries no unauthored boilerplate', ({ cls }) => {
+    // This row has now been inverted TWICE, so the history is worth keeping.
     //
     // Step 1 shipped `commandMeta` as pure identity and asserted these three
-    // fields were ABSENT here, because that was shape-preserving for the three
-    // classes it converted. Step 3 chose the other way — `commandMeta` fills
-    // `isBlocking`/`hasBody`/`version` exactly as `@meta` did — because that is
-    // what keeps the FIFTY-TWO classes it migrated byte-identical, which is the
-    // larger preservation. The cost is these three gaining the fields, and this
-    // assertion is that cost, written down.
+    // fields were ABSENT. Step 3 inverted it — `commandMeta` filled
+    // `isBlocking`/`hasBody`/`version` exactly as `@meta` did — because that
+    // kept the 52 classes it migrated byte-identical, which was the larger
+    // preservation at the time. The comment then said, correctly, that the
+    // values were boilerplate and false for other commands, and that fixing it
+    // was a separate filed item.
     //
-    // The values are boilerplate and two of them are false for other commands
-    // (`wait`/`fetch` do block, `if`/`repeat` do take bodies). Authoring them
-    // truthfully is a separate, filed item — do NOT quietly fix it here.
+    // This is that item, resolved the other way: not by authoring 59 truthful
+    // booleans, but by not publishing a claim nobody made. See the registry-wide
+    // assertion below for why that is the safer direction.
     const md = cls.metadata as Record<string, unknown>;
-    expect(md.isBlocking).toBe(false);
-    expect(md.hasBody).toBe(false);
-    expect(md.version).toBe('1.0.0');
+    expect(md).not.toHaveProperty('isBlocking');
+    expect(md).not.toHaveProperty('hasBody');
+    expect(md).not.toHaveProperty('version');
   });
 
   it.each(CONVERTED)('$name carries a compatibility value (step 3)', ({ cls }) => {

--- a/packages/core/src/commands/decorators/index.ts
+++ b/packages/core/src/commands/decorators/index.ts
@@ -86,13 +86,14 @@ export function command(config: CommandConfig) {
 // ============================================================================
 
 /**
- * Input accepted by {@link commandMeta}: `CommandMetadata` with `version`
- * optional, since it is a published constant rather than something an author
- * chooses per command.
+ * Input accepted by {@link commandMeta} — the canonical `CommandMetadata`.
+ *
+ * This used to re-declare `version` as optional, which was already true on
+ * `CommandMetadata`; the `Omit` had no effect once `commandMeta` stopped
+ * defaulting it. Kept as a named alias because it is the published name of
+ * `commandMeta`'s parameter type.
  */
-export type CommandMetaInput = Omit<CommandMetadata, 'version'> & {
-  readonly version?: string;
-};
+export type CommandMetaInput = CommandMetadata;
 
 /**
  * Declare a command's metadata as a **type-visible** static.
@@ -129,30 +130,33 @@ export type CommandMetaInput = Omit<CommandMetadata, 'version'> & {
  * excess-property and enum checking fire. Drop `const` and the arc trades
  * inference for checking instead of getting both.
  *
- * ## The defaults, and why they are here
+ * ## Why there are no longer any defaults
  *
- * Fills `isBlocking`/`hasBody`/`version` exactly as `@meta` did, so the 52
- * classes step 3 migrated keep byte-identical metadata. Step 1 shipped this as a
- * pure identity function and said the choice had to be made deliberately in step
- * 3 rather than by omission; this is that decision. The cost is that the three
- * `commandMeta` classes migrated in step 1 (`install`, `pseudo-command`,
- * `render`) now GAIN the three fields — a change their tests assert explicitly,
- * so it shows up as a moved row rather than as drift.
+ * This filled `isBlocking`/`hasBody`/`version` exactly as `@meta` did, so that
+ * Arc B's migration stayed byte-identical. That was a refactor-preserving
+ * choice, explicitly not an endorsement — and it published a falsehood: since
+ * NO command literal ever set them, every row of the generated
+ * `docs/commands/commands.json` carried `isBlocking: false`, `hasBody: false`,
+ * `version: '1.0.0'` with zero variance across all **59** commands. That says
+ * `wait`, `fetch`, `settle` and `transition` do not block, and that `if`,
+ * `repeat` and `tell` take no body. All false, and it got worse as the command
+ * set grew (it was 40/43 when the defect was filed).
  *
- * Spread order is load-bearing: the defaults come first, so a literal that
- * states `isBlocking: true` wins and still narrows to `true`.
+ * The queue framed the fix as authoring ~59 truthful booleans. Measured, that
+ * is the wrong end: the fields are **unauthored, unread, and unrendered** —
+ * nothing in production or in `REFERENCE.md` consumes them, and no gate pins
+ * them. Emitting them at all is the only thing that creates the false claim, so
+ * they are simply gone. `version` was meaningless per-command regardless (the
+ * JSON's document-level `version` is a separate, real field).
  *
- * **These three fields are unauthored and unread.** No command literal sets
- * them, nothing in production reads them, and every one of the 40 rows in the
- * shipped `docs/commands/commands.json` therefore says `isBlocking: false`,
- * `hasBody: false`, `version: '1.0.0'` — which is FALSE for `wait`, `fetch`,
- * `settle`, `transition` (they block) and for `if`, `repeat`, `tell` (they take
- * bodies). Preserving them here is deliberately a refactor-preserving choice,
- * not an endorsement; authoring them truthfully is filed as its own item in
- * `docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md`.
+ * They remain OPTIONAL on {@link CommandMetadata}: a command that genuinely
+ * needs to declare `isBlocking: true` still can, and now that declaration means
+ * something because absence no longer reads as a claim of `false`. If a
+ * consumer ever appears, prefer deriving over hand-authoring — `COMPOUND_COMMANDS`
+ * and the parser's `CommandNode.isBlocking` already encode much of it.
  */
 export function commandMeta<const T extends CommandMetaInput>(metadata: T) {
-  return { isBlocking: false, hasBody: false, version: '1.0.0', ...metadata };
+  return { ...metadata };
 }
 
 // ============================================================================

--- a/packages/core/src/types/command-metadata.ts
+++ b/packages/core/src/types/command-metadata.ts
@@ -267,19 +267,27 @@ export interface CommandMetadata {
 
   /**
    * Semantic version string
-   * @optional @default '1.0.0'
+   * @optional — no default; `commandMeta()` does not fill it
    */
   readonly version?: string;
 
   /**
-   * Whether this command is blocking (waits for completion)
-   * @optional @default false
+   * Whether this command is blocking (waits for completion).
+   *
+   * @optional — **absent means UNDECLARED, not `false`.** `commandMeta()`
+   * used to default this (and `hasBody`) to `false`, which published a claim
+   * no author had made: all 59 commands stated they do not block, including
+   * `wait`, `fetch`, `settle` and `transition`, which do. The default is gone,
+   * so setting this now carries meaning. Prefer deriving over hand-authoring —
+   * the parser's `CommandNode.isBlocking` already encodes much of it.
    */
   readonly isBlocking?: boolean;
 
   /**
-   * Whether this command accepts a body (commands between start and 'end')
-   * @optional @default false
+   * Whether this command accepts a body (commands between start and 'end').
+   *
+   * @optional — absent means UNDECLARED, not `false`; see {@link CommandMetadata.isBlocking}.
+   * `COMPOUND_COMMANDS` and the block-command set already encode much of this.
    */
   readonly hasBody?: boolean;
 


### PR DESCRIPTION
Closes the two Phase H owner-decision items. One is fixed; the other is closed
as **not worth doing**, because measuring it falsified its own filing — and that
measurement found something bigger, which is filed rather than fixed.

## Fixed: `isBlocking` / `hasBody` / `version`

`commandMeta()` spread `{ isBlocking: false, hasBody: false, version: '1.0.0' }`
as defaults. No command literal ever overrode them, so every row of the generated
`docs/commands/commands.json` carried all three with **zero variance across all
59 commands** — asserting that `wait`, `fetch`, `settle` and `transition` do not
block, and that `if`, `repeat` and `tell` take no body. All false, and worse than
when filed (it was 40/43 then).

Arc B preserved the boilerplate deliberately, to keep its migration a pure
refactor, and filed the truthful version as "~59 judgment calls with its own
review surface."

**That is the wrong end of the problem.** Measured, the fields are *unauthored,
unread, and unrendered*:

| | |
| --- | --- |
| authored by a command literal? | never — all 59 values came from the default |
| read in production? | no |
| rendered in `REFERENCE.md`? | no — it is **byte-identical** after this change |
| pinned by a gate? | no |
| shipped to npm? | no — `commands.json` is not in `package.json`'s `files` |

Defaulting them was the entire source of the falsehood, so the defaults are gone
and the three keys vanish from all 59 rows — a **pure 177-line deletion** (59 × 3),
with no other change to the artifact.

The fields stay OPTIONAL on `CommandMetadata`, and **absence now means UNDECLARED
rather than `false`**. That is the real win: a future truthful `isBlocking: true`
now carries meaning, where before it was indistinguishable from boilerplate. If a
consumer ever appears, prefer deriving over hand-authoring — `COMPOUND_COMMANDS`
and the parser's `CommandNode.isBlocking` already encode much of it.

**Gated registry-wide**, not over the three classes the old assertion happened to
cover: `command-meta.test.ts` fails if any of the three appears on *every*
registered command — the signature of the default returning — while still
allowing a few truthful declarations. Mutation-verified; restoring the defaults
reddens it with a diagnostic naming the failure mode:

```text
isBlocking is declared on 59/59 commands. If that equals the registry size,
commandMeta() is defaulting it again — which publishes a claim no author made.
A few truthful declarations are fine; all of them is the bug.
```

`CommandMetaInput`'s `Omit<CommandMetadata, 'version'>` also collapses to
`CommandMetadata`: `version` was already optional, so the `Omit` did nothing once
the default went away.

## Closed without code: F-B1, the shadow `CommandMetadata`

The filing asks for the adapter's loose `CommandMetadata` to be narrowed to the
canonical type. I ran that experiment (swap the type, typecheck). It produces 9
errors and **falsifies three of the filing's four claims**:

- **"`impl.metadata?.name` at `:421` typechecks only because of the index
  signature."** No — the enclosing signature is `register(impl: any)`, so the
  parameter's `any` is what defeats checking there. `:421` does not error at all.
  The erroring sites are `:207` (the `get name()` getter) and `:211`.
- **"Contained to one file, no cross-package ripple."** No — 7 of the 9 errors are
  `category: 'server'` in `registry/examples/server-commands.ts` and
  `registry/multilingual/examples.ts`, absent from the canonical union. That drags
  in F-B2, which is deliberately pinned as "a rename with LSP and docs reach."
- **"A behavior question: the fallback is the only path for a V1 command carrying
  `metadata.name`."** True in principle, vacuous in practice — all 55 command
  classes (52 decorated, plus `install`/`pseudo-command`/`render` with
  `readonly name = '…'`) carry a top-level `name`, so the fallback is dead for
  everything that ships. Only `runtime.test.ts`'s third-party-shape test reaches it.

Paying a union reconciliation to fix a hole that is not where the filing put it is
not a good trade. Both docs now carry the measurement.

## Filed, not fixed: the defect that measurement actually found

Typing `register()` — or `COMMAND_FACTORIES`, which is currently
`Readonly<Record<string, () => unknown>>`, so the manifest-driven registration of
all 59 commands is unchecked end to end — surfaces **59 identical errors**:

```text
The types returned by 'validate(...)' are incompatible between these types.
  Type 'boolean' is not assignable to type 'ValidationResult<unknown>'.
```

`CommandWithParseInput` declares `validate?(input): ValidationResult<unknown>`.
Every real command implements `validate(input): input is XInput` — a **boolean
type guard**. So `CommandAdapterV2.validate()` would return a boolean while its
signature promises `{ isValid, errors, suggestions }`. The registry's own private
map is typed `Map<string, CommandWithParseInput>`, so the interface describes no
command it actually holds.

It has never bitten because the only consumer,
`CommandRegistryV2.validateCommand()`, is **called by nobody**. That makes it a
latent whole-registry contract lie, and which contract is the real one is an
owner decision — so it is filed in `COMMAND_ARCHITECTURE_NEXT_STEPS.md` with a
note not to "fix" it by widening the interface to `boolean | ValidationResult`,
which would preserve the ambiguity that let the two drift.

## Gates

core 7917 tests / 308 files · `docs:commands:check` · `verify:reference` · root
`test:check` 39 packages · `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
