### PR TITLE
fix(core): type the command registration path — 55 registrations were unchecked end to end

### DIFF
--- a/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
+++ b/docs-internal/COMMAND_ARCHITECTURE_NEXT_STEPS.md
@@ -725,10 +725,50 @@ not the core abstractions.
   filing put it. **What the experiment DID find is bigger and is filed fresh
   below.**
 
-- **`CommandWithParseInput` describes no real command, and `register(impl: any)`
-  is what hides it.** (Opened 2026-08-01, out of the F-B1 measurement.) The
-  registry's own private map is `Map<string, CommandWithParseInput>`
-  (`command-adapter.ts:380`), and `COMMAND_FACTORIES` is
+- ~~**`CommandWithParseInput` describes no real command, and `register(impl: any)`
+  is what hides it.**~~ **FIXED 2026-08-01.** `register` takes
+  `CommandWithParseInput` and `COMMAND_FACTORIES` is
+  `Readonly<Record<string, () => CommandWithParseInput>>`, so the
+  manifest-driven registration path is checked end to end. Probed for vacuity
+  rather than assumed: drifting `execute`'s input parameter produces **64
+  compile errors** across the factory map, and 0 after restore.
+
+  **The owner decision the filing asked for was answered — and three of its four
+  measurements were wrong.** Each mattered:
+
+  1. **`validate` is the type guard**, confirmed: 17 implementations (not 59 —
+     most commands declare none), all `input is XInput`, plus **185 assertions
+     across 21 test files** already pinning the boolean. The interface says
+     `boolean` now; `CommandAdapterV2.validate()` LIFTS it into
+     `ValidationResult` at the boundary, which is where the struct was always
+     the right shape.
+  2. **`RuntimeCommand.validate` is NOT its twin — it is its opposite.**
+     `CommandAdapterV2 implements RuntimeCommand`, so that signature is the
+     ADAPTER's outward contract and correctly stays a `ValidationResult`; it is
+     what `validateCommand()` reports. The filing read the two identical
+     signatures as one drift; changing both would have deleted the wrap.
+  3. **The predicted "59 errors, all the same" never appeared.** After the
+     `validate` line was fixed the remaining 60 errors were an unrelated class:
+     `commandMeta<const T>` infers **readonly** tuples by design (the `const`
+     type parameter is what buys excess-property and enum checking), while
+     `CommandMetadata` declared mutable `string[]`. That, not `validate`, is why
+     `register` could only ever have been `any`. Also surfaced: `execute` was
+     declared `Promise<unknown>` though the adapter awaits it and `GetCommand` /
+     `RemoveCommand` are synchronous, with `get.test.ts` asserting the sync
+     return across eight rows — so the interface, not those commands, was the
+     thing mis-declared.
+
+  The `boolean | ValidationResult` prohibition below was respected: nothing was
+  widened, and no `category: 'server'` error appeared (those came from the
+  different shadow-`CommandMetadata` experiment, so F-B2 stayed pinned).
+  `validateCommand()` still has no production caller, but it is now covered by
+  four mutation-verified rows in `runtime.test.ts` — restoring the pass-through
+  reddens two of them.
+
+  Original filing follows.
+
+  The registry's own private map is `Map<string, CommandWithParseInput>`
+  (`command-adapter.ts:380`), and `COMMAND_FACTORIES` was
   `Readonly<Record<string, () => unknown>>` (`runtime.ts:137`) — so the
   manifest-driven registration of all 59 commands is unchecked end to end.
   Typing either one produces **59 errors, all the same**:

--- a/packages/core/src/runtime/__tests__/command-manifest-audit.test.ts
+++ b/packages/core/src/runtime/__tests__/command-manifest-audit.test.ts
@@ -218,7 +218,10 @@ describe('the registry', () => {
     expect(COMMANDS.has(name)).toBe(false);
 
     const registry = new Runtime().getRegistry();
-    registry.register({ name, metadata: { name, aliases: ['audit-synthetic-alias'] } });
+    // No `execute`: the row is about the `COMMANDS.add(name)` side effect, which
+    // fires before any execution could. `register` is typed since 2026-08-01, so
+    // the stub needs the cast.
+    registry.register({ name, metadata: { name, aliases: ['audit-synthetic-alias'] } } as never);
 
     expect(COMMANDS.has(name)).toBe(true);
     expect(COMMANDS.has('audit-synthetic-alias')).toBe(true);

--- a/packages/core/src/runtime/command-adapter.ts
+++ b/packages/core/src/runtime/command-adapter.ts
@@ -38,10 +38,21 @@ const canonicalEvaluator: ExpressionEvaluator = {
 export interface RuntimeCommand {
   name: string;
   execute(context: ExecutionContext, ...args: unknown[]): Promise<unknown>;
+  /**
+   * The ADAPTER's outward contract — `CommandAdapterV2 implements RuntimeCommand`
+   * — so this legitimately stays a `ValidationResult`: it is what
+   * `CommandRegistryV2.validateCommand()` reports to a caller. Do NOT confuse it
+   * with {@link CommandWithParseInput.validate}, which is the boolean type guard
+   * a COMMAND writes and which the adapter lifts into this shape. The two look
+   * like twins and are opposites: one is the report, the other the predicate.
+   */
   validate?(input: unknown): ValidationResult<unknown>;
   metadata?: {
     description: string;
-    examples: string[];
+    // Readonly for the same reason as CommandMetadata's below: the adapter's
+    // getter forwards the command's own `commandMeta<const T>` tuple through.
+    examples: readonly string[];
+    // Already normalized by the getter — a `string[]` syntax is joined with ' | '.
     syntax: string;
   };
 }
@@ -53,9 +64,15 @@ export interface RuntimeCommand {
  */
 export interface CommandMetadata {
   description?: string;
-  examples?: string[];
-  syntax?: string | string[];
-  aliases?: string[];
+  // READONLY arrays, because `commandMeta<const T>` (commands/decorators) infers
+  // readonly tuples by design — the `const` type parameter is what gives it
+  // excess-property and enum checking. Declaring these mutable made every real
+  // command unassignable to this interface, which is the reason `register` could
+  // only ever have been typed `any`. The registry never mutates them; it reads
+  // `aliases` and nothing else.
+  examples?: readonly string[];
+  syntax?: string | readonly string[];
+  aliases?: readonly string[];
   [extra: string]: unknown;
 }
 
@@ -85,8 +102,30 @@ export interface CommandWithParseInput {
     evaluator: { evaluate(node: ASTNode, context: ExecutionContext): Promise<unknown> },
     context: ExecutionContext
   ): Promise<unknown>;
-  execute(input: unknown, context: TypedExecutionContext): Promise<unknown>;
-  validate?(input: unknown): ValidationResult<unknown>;
+  /**
+   * The return is `unknown`, not `Promise<unknown>`, because the adapter AWAITS
+   * it (`result = await this.impl.execute(...)`) and several commands are
+   * legitimately synchronous — `GetCommand.execute` returns `GetCommandOutput`
+   * and `RemoveCommand.execute` returns `void`, with `get.test.ts` asserting
+   * that synchronous return directly across eight rows. Declaring
+   * `Promise<unknown>` described neither the callee nor the caller; it merely
+   * went unchecked while `register` took `any`. The PARAMETER list is where this
+   * interface earns its keep — that is what catches a drifted signature.
+   */
+  execute(input: unknown, context: TypedExecutionContext): unknown;
+  /**
+   * Narrowing TYPE GUARD over this command's own input shape — every one of the
+   * 17 implementations is written `validate(input: unknown): input is XInput`,
+   * and 185 assertions across 21 test files pin the boolean result.
+   *
+   * This was declared as `ValidationResult<unknown>` until 2026-08-01, which no
+   * command has ever returned. `CommandAdapterV2.validate()` passed the raw
+   * boolean straight through under that type; the lie went unnoticed only
+   * because its sole consumer, `CommandRegistryV2.validateCommand()`, is called
+   * by nobody. The struct shape is still what the registry method REPORTS — the
+   * adapter wraps at that boundary — but it was never the command contract.
+   */
+  validate?(input: unknown): boolean;
   metadata?: CommandMetadata;
 }
 
@@ -218,7 +257,10 @@ export class CommandAdapterV2 implements RuntimeCommand {
     return {
       description: this.impl.metadata?.description || '',
       examples: this.impl.metadata?.examples || [],
-      syntax: Array.isArray(syntax) ? syntax.join(' | ') : syntax || '',
+      // `typeof`, not `Array.isArray`: the latter narrows to `any[]` and leaves
+      // `readonly string[]` in the else branch, so the getter's own return type
+      // stopped matching `RuntimeCommand.metadata.syntax: string`.
+      syntax: typeof syntax === 'string' ? syntax : syntax ? syntax.join(' | ') : '',
     };
   }
 
@@ -358,11 +400,16 @@ export class CommandAdapterV2 implements RuntimeCommand {
     }
   }
 
+  /**
+   * Lift a command's boolean type guard into the `ValidationResult` shape the
+   * registry reports. The wrap happens HERE, at the boundary, rather than in 17
+   * command bodies — the guard is what commands are written to return and what
+   * their tests assert. Before 2026-08-01 this passed the raw boolean straight
+   * through while promising a struct.
+   */
   validate(input: unknown): ValidationResult<unknown> {
-    if (this.impl.validate) {
-      return this.impl.validate(input);
-    }
-    return { isValid: true, errors: [], suggestions: [] };
+    const isValid = this.impl.validate ? this.impl.validate(input) : true;
+    return { isValid, errors: [], suggestions: [] };
   }
 }
 
@@ -413,12 +460,21 @@ export class CommandRegistryV2 {
   }
 
   /**
-   * Register a command (V1 or V2 format)
-   * Uses 'any' to accept all command implementations with compatible structure
-   * Also registers any aliases defined in metadata
+   * Register a command, and any aliases its metadata declares.
+   *
+   * Typed to the interface the registry actually stores. It took `any` until
+   * 2026-08-01, which meant all 55 manifest-driven registrations were unchecked
+   * end to end — a drifted `execute` signature compiled silently, and the
+   * `Map<string, CommandWithParseInput>` below asserted a shape nothing had
+   * verified. Typing it required fixing what the interface said, not what the
+   * commands do: readonly metadata tuples and a non-Promise `execute` return.
+   *
+   * The `metadata.name` fallback is kept because the error message promises it,
+   * but no in-tree command relies on it: `metadata` is index-signature typed, so
+   * that branch yields `unknown` and the runtime string check is what narrows.
    */
-  register(impl: any): void {
-    const rawName = impl.name || impl.metadata?.name;
+  register(impl: CommandWithParseInput): void {
+    const rawName: unknown = impl.name || impl.metadata?.name;
     if (!rawName || typeof rawName !== 'string') {
       throw new Error(
         `Cannot register command: no name found. ` +

--- a/packages/core/src/runtime/runtime.test.ts
+++ b/packages/core/src/runtime/runtime.test.ts
@@ -421,14 +421,20 @@ describe('Runtime Audit Fixes', () => {
   });
 
   describe('CommandRegistryV2.register() validation', () => {
+    // These two pass DELIBERATELY malformed objects to exercise the runtime
+    // throw, which is what protects callers who reach `register` from
+    // JavaScript. `register` is typed since 2026-08-01, so they need the cast —
+    // the cast IS the point of the row, not a workaround around one.
     it('should throw descriptive error for commands with no name', () => {
       const registry = new CommandRegistryV2();
-      expect(() => registry.register({})).toThrow('Cannot register command: no name found');
+      expect(() => registry.register({} as never)).toThrow(
+        'Cannot register command: no name found'
+      );
     });
 
     it('should throw for undefined name and metadata', () => {
       const registry = new CommandRegistryV2();
-      expect(() => registry.register({ metadata: {} })).toThrow(
+      expect(() => registry.register({ metadata: {} } as never)).toThrow(
         'Cannot register command: no name found'
       );
     });
@@ -446,13 +452,60 @@ describe('Runtime Audit Fixes', () => {
 
     it('should accept commands with metadata.name', () => {
       const registry = new CommandRegistryV2();
+      // Cast: `CommandWithParseInput` requires a top-level `name`, but the
+      // runtime deliberately falls back to `metadata.name` and the error message
+      // promises that fallback. No in-tree command uses it — this row is the
+      // only thing keeping the branch honest.
       expect(() =>
         registry.register({
           metadata: { name: 'meta-test' },
           execute: async () => {},
-        })
+        } as never)
       ).not.toThrow();
       expect(registry.has('meta-test')).toBe(true);
+    });
+  });
+
+  describe('CommandRegistryV2.validateCommand() reports a well-formed result', () => {
+    // The adapter LIFTS a command's boolean type guard into `ValidationResult`.
+    // Until 2026-08-01 it passed the raw boolean straight through while its
+    // signature promised the struct, so `validateCommand()` returned `true` /
+    // `false` where callers would read `.isValid` — `undefined` either way, so
+    // an invalid input read as valid. Nothing caught it because the method has
+    // no callers; these rows are what make the wrap load-bearing.
+    const guardCommand = {
+      name: 'guard-test',
+      execute: async () => undefined,
+      validate: (input: unknown): boolean => typeof input === 'number',
+    };
+
+    it('wraps a passing guard', () => {
+      const registry = new CommandRegistryV2();
+      registry.register(guardCommand);
+      expect(registry.validateCommand('guard-test', 42)).toEqual({
+        isValid: true,
+        errors: [],
+        suggestions: [],
+      });
+    });
+
+    it('wraps a FAILING guard — the row that reads `false` as valid without the wrap', () => {
+      const registry = new CommandRegistryV2();
+      registry.register(guardCommand);
+      const result = registry.validateCommand('guard-test', 'not a number');
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('defaults to valid for a command that declares no guard', () => {
+      const registry = new CommandRegistryV2();
+      registry.register({ name: 'no-guard', execute: async () => undefined });
+      expect(registry.validateCommand('no-guard', {}).isValid).toBe(true);
+    });
+
+    it('reports an unknown command as invalid rather than throwing', () => {
+      const registry = new CommandRegistryV2();
+      expect(registry.validateCommand('nope', {}).isValid).toBe(false);
     });
   });
 

--- a/packages/core/src/runtime/runtime.ts
+++ b/packages/core/src/runtime/runtime.ts
@@ -20,7 +20,7 @@
  */
 
 import { RuntimeBase, type RuntimeBaseOptions } from './runtime-base';
-import { CommandRegistryV2 } from './command-adapter';
+import { CommandRegistryV2, type CommandWithParseInput } from './command-adapter';
 import { createFullExpressionRegistry } from '../expressions/index';
 import { COMMAND_MANIFEST } from '../commands/manifest';
 
@@ -134,7 +134,7 @@ import { createRenderCommand } from '../commands/templates/render';
  * manifest itself (Finding 9). It lives here because `runtime.ts` is the one
  * module that legitimately references every command implementation.
  */
-const COMMAND_FACTORIES: Readonly<Record<string, () => unknown>> = {
+const COMMAND_FACTORIES: Readonly<Record<string, () => CommandWithParseInput>> = {
   // DOM
   hide: createHideCommand,
   show: createShowCommand,


### PR DESCRIPTION
Closes item #1b from the handoff (`COMMAND_ARCHITECTURE_NEXT_STEPS.md` § "`CommandWithParseInput` describes no real command, and `register(impl: any)` is what hides it").

## The hole

`CommandRegistryV2.register` took `any` and `COMMAND_FACTORIES` was `Readonly<Record<string, () => unknown>>`, so **every manifest-driven registration was unverified**: a drifted `execute` signature compiled silently, while the registry's own `Map<string, CommandWithParseInput>` asserted a shape nothing had checked. Both are typed now.

**Probed for vacuity rather than assumed:** drifting `execute`'s input parameter produces **64 compile errors** across the factory map, and **0** after restore.

## The owner decision, answered

`validate` **is** the boolean type guard. Confirmed by measurement: **17 implementations** (not 59 — most commands declare none), every one written `input is XInput`, with **185 assertions across 21 test files** already pinning the boolean. `CommandAdapterV2.validate()` now *lifts* it into `ValidationResult` at the boundary instead of passing a raw boolean through under a signature promising a struct.

## Three of the filing's four measurements were wrong

Each one mattered:

1. **`RuntimeCommand.validate` is not `CommandWithParseInput.validate`'s twin — it is its opposite.** `CommandAdapterV2 implements RuntimeCommand`, so that signature is the **adapter's outward contract** and correctly stays a `ValidationResult`; it is what `validateCommand()` reports. The filing read two identical signatures as one drift, and the plan said to change both — which would have deleted the very wrap it was asking for.
2. **The predicted "59 errors, all the same: `Type 'boolean' is not assignable to ValidationResult`" never appeared.** Once the `validate` line was fixed, the remaining 60 errors were an unrelated class: `commandMeta<const T>` infers **readonly tuples by design** (the `const` type parameter is what buys excess-property and enum checking), while `CommandMetadata` declared mutable `string[]`. *That*, not `validate`, is what made every real command unassignable — the actual reason `register` could only ever have been `any`.
3. **`execute` was declared `Promise<unknown>` though the adapter awaits it** and two commands are synchronous (`GetCommand` returns `GetCommandOutput`, `RemoveCommand` returns `void`), with `get.test.ts` asserting that sync return across eight rows. The interface was mis-declared, not the commands — making them `async` to satisfy a type I picked would have broken real tests for no behavioral gain. The **parameter list** is where this interface earns its keep.

Also fixes the `metadata` getter's `Array.isArray` narrowing, which yields `any[]` and left `readonly string[]` in the else branch.

## New coverage

`validateCommand()` had **zero** tests — which is why the contract lie survived (it has no production caller either). Four rows now pin it, mutation-verified: restoring the pass-through reddens two, including the one that reads a **failing** guard as valid (`false.isValid` is `undefined`, so an invalid input read as valid).

## Out of scope, as the filing directs

- Nothing widened to `boolean | ValidationResult`.
- No `category: 'server'` error appeared — those came from the different shadow-`CommandMetadata` experiment — so **F-B2 stays pinned**.
- Test casts are `as never`, only on the deliberately-malformed registrations that exercise the runtime throw, plus the audit test's no-`execute` stub whose `COMMANDS.add` side effect is the point of the row.

## Verification

`npm run typecheck --prefix packages/core` clean · core suite **7929 passed** · root `npm run test:check` green · `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)