### PR TITLE
fix(parser): `tell #modal to show` retargeted silently, and tell's `end` leaked to enclosing blocks

### DIFF
--- a/docs-internal/PARSER_NEXT_STEPS.md
+++ b/docs-internal/PARSER_NEXT_STEPS.md
@@ -25,8 +25,8 @@ ones, because the gate *is* the tracking mechanism.
 | Item | Severity | Gate | Detail |
 | ---- | -------- | ---- | ------ |
 | **Or-join filters have no per-event representation** | low — `on click or keypress[key=='Enter']` runs keypress unfiltered (upstream filters that leg); single-event filters ARE enforced | ✅ KNOWN GAP test | `packages/core/src/api/event-filter-execution.test.ts`; the runtime-side note at the `applicableCondition` site in `runtime-base.ts` |
-| **`tell` never consumes a terminating `end`** | medium — no real `tell … end` block form; upstream requires one | **none** | comment at `packages/core/src/parser/command-parsers/utility-commands.ts` (the `ELSE`/`END` break in `parseTellCommand`) |
-| **`tell <target> to <command>` drops the `tell` wrapper** | medium — **silent wrong target** on the form users actually write | **none** | see the measured table below; found by Arc A step 4.3 (Finding 14 in [HANDOFF-command-arch-manifest.md](./HANDOFF-command-arch-manifest.md)), re-verified 2026-07-29 |
+| ~~**`tell` never consumes a terminating `end`**~~ | **FIXED 2026-08-01** — tell consumes its own `end`; the real damage was nested (post-`end` commands escaped `if`/`repeat` bodies), not the filed "no block form" | ✅ `tell-to-and-end.test.ts` | history below |
+| ~~**`tell <target> to <command>` drops the `tell` wrapper**~~ | **FIXED 2026-08-01** — optional `to` consumed after the target (deliberate superset; upstream rejects the form, but hyperfixi's error recovery turned the throw into the silent retarget) | ✅ `tell-to-and-end.test.ts` (mutation-verified both halves) | history below |
 | **`set <idref> to <value>` / js property-path args no-op** | medium — silent no-effect on shipped pages | ✅ execution-gate allowlist entries | families 1/6 in [HANDOFF-shipped-examples-execution.md](HANDOFF-shipped-examples-execution.md) |
 | **`for <duration>` tail rejected on `toggle` / `wait`** | medium — two upstream-valid forms on shipped, documented commands; both are the command's OWN documented example | **none** | see the measured table below; found by the Arc B examples sweep ([HANDOFF-command-arch-metadata.md](./HANDOFF-command-arch-metadata.md) § F-B4a) |
 | ~~**`transition` rejects a POSSESSIVE property target**~~ | **FIXED 2026-07-31** — optional leading target in `parseTransitionCommand` (all four shapes), emitting the `[target, property]` args the runtime already discriminated on | e2e tests, both paths | `packages/core/src/commands/animation/__tests__/transition-target.test.ts`; history below |
@@ -54,10 +54,48 @@ ones, because the gate *is* the tracking mechanism.
   of BOTH legs; per-event condition representation flips both halves, so the
   fix is forced to be deliberate and visible.
 
-The ungated ones (both `tell` entries) have no such mechanism. **They are what
-this document is for.**
+The last ungated entries (both `tell` rows) closed 2026-08-01 with their own
+gate. **The remaining open item is the `wait for click or 1s` half of the
+`for <duration>` row — it is gate-less and is what this document is for.**
 
-### `tell <target> to <command>` — the measured shape
+### ~~`tell <target> to <command>` — the measured shape~~ — BOTH tell rows FIXED (2026-08-01)
+
+Both fixed in `parseTellCommand`, gated by
+`packages/core/src/parser/__tests__/tell-to-and-end.test.ts` (13 rows, both
+halves mutation-verified: reverting the `to` consumption reddens 6, reverting
+the `end` consumption reddens 3).
+
+- **The dropped wrapper**: parseTellCommand now consumes an optional `to`
+  after the target. Upstream REJECTS the form loudly (`Expected 'end' but
+  found 'to'` — measured on the real engine), but hyperfixi could not throw
+  its way to safety: `parseCommandWithErrorRecovery` swallows any
+  command-parser throw inside handler bodies and the stranded body re-parses
+  as top-level commands, which was the whole silent-retarget mechanism.
+  Consuming the word is the only fix the recovery machinery cannot un-fix,
+  and is a deliberate superset of upstream grammar (pick's legacy forms
+  precedent). The bare form went from a loud failure to working.
+- **The missing terminator**: tell now CONSUMES a directly-following `end`,
+  matching upstream's `requireToken("end")`. Re-measuring first showed the
+  filed severity was half-wrong in an interesting way: at handler level the
+  leftover `end` was absorbed harmlessly (every filed-adjacent row already
+  matched upstream structurally), but inside a block it mis-attributed
+  everything after it — `on click if true tell #modal show end log "x" end`
+  gave the leftover `end` to the IF, so `log` escaped the conditional and ran
+  unconditionally; the `repeat` twin ran its trailing command once instead of
+  per-iteration. Both nested rows measured VALID upstream with the command
+  INSIDE the block. One residue, deliberate: `if true tell #m show end log
+  "x"` (a single `end` where two closings are needed) now records a
+  recoverable "Expected 'end' after if block" diagnostic while building the
+  upstream-matching tree — stricter than upstream's silence, and arguably
+  more honest about the ambiguous source.
+
+`parseCommandWithErrorRecovery`'s throw-swallowing itself remains: ANY
+command parser that throws inside a handler body still degrades silently
+(tell was just its worst client). That is a general machinery question, not a
+tell defect, and is NOT tracked elsewhere — if another silent command-drop
+surfaces, start there.
+
+Original filing kept below for the record.
 
 Both `tell` rows are in `parseTellCommand`, but they are separate defects: the
 one above is a missing terminator, this one is a **dropped wrapper**, and this

--- a/docs-internal/PARSER_NEXT_STEPS.md
+++ b/docs-internal/PARSER_NEXT_STEPS.md
@@ -28,7 +28,7 @@ ones, because the gate *is* the tracking mechanism.
 | ~~**`tell` never consumes a terminating `end`**~~ | **FIXED 2026-08-01** — tell consumes its own `end`; the real damage was nested (post-`end` commands escaped `if`/`repeat` bodies), not the filed "no block form" | ✅ `tell-to-and-end.test.ts` | history below |
 | ~~**`tell <target> to <command>` drops the `tell` wrapper**~~ | **FIXED 2026-08-01** — optional `to` consumed after the target (deliberate superset; upstream rejects the form, but hyperfixi's error recovery turned the throw into the silent retarget) | ✅ `tell-to-and-end.test.ts` (mutation-verified both halves) | history below |
 | **`set <idref> to <value>` / js property-path args no-op** | medium — silent no-effect on shipped pages | ✅ execution-gate allowlist entries | families 1/6 in [HANDOFF-shipped-examples-execution.md](HANDOFF-shipped-examples-execution.md) |
-| **`for <duration>` tail rejected on `toggle` / `wait`** | medium — two upstream-valid forms on shipped, documented commands; both are the command's OWN documented example | **none** | see the measured table below; found by the Arc B examples sweep ([HANDOFF-command-arch-metadata.md](./HANDOFF-command-arch-metadata.md) § F-B4a) |
+| ~~**`for <duration>` tail rejected on `toggle` / `wait`**~~ | **BOTH FIXED** — toggle via `parseTemporalTail` (2026-07-31); wait via #850's duration alternatives in the `for` loop (`wait for click or 1s` races event vs timeout) — **the table below still listed the wait half as open a day after it shipped** | ✅ `wait-event-or-duration.test.ts` + toggle temporal tests | history below |
 | ~~**`transition` rejects a POSSESSIVE property target**~~ | **FIXED 2026-07-31** — optional leading target in `parseTransitionCommand` (all four shapes), emitting the `[target, property]` args the runtime already discriminated on | e2e tests, both paths | `packages/core/src/commands/animation/__tests__/transition-target.test.ts`; history below |
 | ~~**`process partials … using view transition` mis-parses**~~ | **FIXED 2026-07-31** — `parseProcessCommand` + dispatch case, runtime raw-keyword rewrite, `process` added to `skipSemanticParsing`; the same unconsumed tail was also fixed on `swap` | ✅ COMPOUND_COMMANDS coverage gate | `packages/core/src/parser/__tests__/compound-command-coverage.test.ts`; history below |
 | ~~**`take <class> from <source>` rejected**~~ | **FIXED 2026-07-31** — `parseTakeCommand` + runtime rewrite (upstream ownership-transfer semantics), `take` added to `skipSemanticParsing` with its toggle/add/remove siblings | e2e tests, both paths | `packages/core/src/commands/animation/__tests__/take-from-for.test.ts`; history below |
@@ -55,8 +55,13 @@ ones, because the gate *is* the tracking mechanism.
   fix is forced to be deliberate and visible.
 
 The last ungated entries (both `tell` rows) closed 2026-08-01 with their own
-gate. **The remaining open item is the `wait for click or 1s` half of the
-`for <duration>` row — it is gate-less and is what this document is for.**
+gate — and re-measuring the queue while closing them found the `wait for click
+or 1s` half of the `for <duration>` row had ALREADY shipped in #850 a day
+before, gated by `wait-event-or-duration.test.ts`, while this table still
+listed it as open. (Third stale filing caught this way; check `git log` on the
+parser file before costing any row here.) **Every row in the table above is
+now either FIXED or protected by a gate that fails on its own. This document
+currently tracks nothing — the next entry added here is what it is for.**
 
 ### ~~`tell <target> to <command>` — the measured shape~~ — BOTH tell rows FIXED (2026-08-01)
 
@@ -121,7 +126,16 @@ Not fixed by Arc A, deliberately: it is a behavior change to the parser with its
 own tests, and folding it into a classification step would have buried that
 step's review artifact.
 
-### `for <duration>` on `toggle` / `wait` — the measured shape
+### ~~`for <duration>` on `toggle` / `wait` — the measured shape~~ — BOTH FIXED
+
+The wait half shipped in **#850** (`c74fb184`, 2026-07-31): the `for` loop's
+alternatives now accept a duration (time literal, bare number, parenthesized
+expression) alongside event names, so `wait for click or 1s` is the
+event-vs-timeout race upstream means, and `WaitCommand`'s `race` input already
+executed it. Gated by
+`packages/core/src/commands/async/__tests__/wait-event-or-duration.test.ts`.
+This table listed the half as open for a day after it shipped — re-measure
+before costing (the row below is the historical record).
 
 Measured 2026-07-29. Each source was parsed on hyperfixi and on the real
 `hyperscript.org` engine (`hs.parse(src).errors`, the loader at
@@ -133,7 +147,7 @@ shipped parser refuses:
 | Source | Upstream | hyperfixi |
 | ------ | -------- | --------- |
 | ~~`toggle .loading for 2s`~~ | accepts | **FIXED** — was `Expected variable name after "for"` |
-| `wait for click or 1s` | accepts | `Expected event name after "for"` |
+| ~~`wait for click or 1s`~~ | accepts | **FIXED (#850)** — was `Expected event name after "for"` |
 
 Both errors read as a `for`-tail being parsed as the start of a loop/event
 construct rather than as a duration modifier, but the two commands take different

--- a/packages/core/src/parser/__tests__/tell-to-and-end.test.ts
+++ b/packages/core/src/parser/__tests__/tell-to-and-end.test.ts
@@ -1,0 +1,187 @@
+/**
+ * `tell` — the two ungated defects from PARSER_NEXT_STEPS.md, fixed together.
+ *
+ * 1. **`tell <target> to <command>` dropped the `tell` wrapper, silently.**
+ *    Upstream REJECTS the `to` form loudly (`Expected 'end' but found 'to'`),
+ *    but hyperfixi's handler bodies route command parses through
+ *    parseCommandWithErrorRecovery, which swallows the throw and lets the
+ *    stranded body re-parse as top-level commands — so `on click tell #modal
+ *    to show` parsed with success:true, 0 errors, no tell node, and `show` ran
+ *    against the handler's `me` instead of #modal. The bare form failed
+ *    loudly, which made the defect read as harmless when probed casually.
+ *    parseTellCommand now consumes an optional `to` after the target — a
+ *    deliberate superset of upstream grammar (pick's legacy forms precedent),
+ *    because it is the only fix the recovery machinery cannot silently un-fix.
+ *
+ * 2. **`tell` never consumed its `end` terminator.** Breaking on `end` left it
+ *    in the stream for whatever enclosed the tell. At handler level that was
+ *    absorbed harmlessly; inside a block it mis-attributed everything after
+ *    it: `if true tell #modal show end log "x" end` gave the leftover `end`
+ *    to the IF, so `log` escaped the conditional and ran unconditionally
+ *    (upstream closes only the tell with it and keeps `log` inside; same
+ *    shape with `repeat`, where the trailing command ran once instead of
+ *    per-iteration). Both nested rows below were measured diverging on main
+ *    and VALID upstream. tell now consumes a directly-following `end`,
+ *    matching upstream's `requireToken("end")`.
+ *
+ * All trees below are asserted structurally (who owns which command), because
+ * `success: true` is not evidence of a command — that is the trap that hid
+ * defect 1 in three engines running.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { parse } from '../parser';
+import { hyperscript } from '../../api/hyperscript-api';
+
+type Tree = { name: string; children: Tree[] };
+
+/** Nested command shape: name plus the commands INSIDE it (args/branches). */
+function commandTree(node: unknown): Tree[] {
+  const out: Tree[] = [];
+  const walk = (n: unknown, into: Tree[]): void => {
+    if (!n || typeof n !== 'object') return;
+    const rec = n as Record<string, any>;
+    if (rec.type === 'command' && typeof rec.name === 'string') {
+      const self: Tree = { name: rec.name, children: [] };
+      into.push(self);
+      for (const k of ['args', 'commands', 'body', 'thenBranch', 'elseBranch']) {
+        const c = rec[k];
+        if (Array.isArray(c)) c.forEach(x => walk(x, self.children));
+        else if (c && typeof c === 'object') walk(c, self.children);
+      }
+      return;
+    }
+    for (const k of ['args', 'commands', 'body', 'thenBranch', 'elseBranch', 'handler']) {
+      const c = rec[k];
+      if (Array.isArray(c)) c.forEach(x => walk(x, into));
+      else if (c && typeof c === 'object') walk(c, into);
+    }
+  };
+  walk(node, out);
+  return out;
+}
+
+/** Flatten to `parent>child` strings for compact assertions. */
+function shape(trees: Tree[], prefix = ''): string[] {
+  return trees.flatMap(t => [prefix + t.name, ...shape(t.children, prefix + t.name + '>')]);
+}
+
+function shapeOf(src: string): { shape: string[]; success: boolean; errors: number } {
+  const r = parse(src) as any;
+  return { shape: shape(commandTree(r.node)), success: r.success, errors: (r.errors ?? []).length };
+}
+
+describe('tell <target> to <command> — the wrapper survives (defect 1)', () => {
+  // The exact measured table from PARSER_NEXT_STEPS.md. On main, the first
+  // three rows parsed success:true / 0 errors with NO tell node.
+  const TO_FORMS: Array<[string, string[]]> = [
+    ['on click tell #modal to show', ['tell', 'tell>show']],
+    ['on click tell .items to add .x', ['tell', 'tell>add']],
+    // `then` joins the body — the joined command runs once per target, inside.
+    ['on click tell #modal to show then log "after"', ['tell', 'tell>show', 'tell>log']],
+  ];
+
+  it.each(TO_FORMS)('%s keeps the body inside tell', (src, expected) => {
+    const r = shapeOf(src);
+    expect(r.success, src).toBe(true);
+    expect(r.errors, src).toBe(0);
+    expect(r.shape, src).toEqual(expected);
+  });
+
+  it('parses the bare form too (previously a loud failure)', () => {
+    const r = shapeOf('tell #modal to show');
+    expect(r.success).toBe(true);
+    expect(r.errors).toBe(0);
+    expect(r.shape).toEqual(['tell', 'tell>show']);
+  });
+
+  it('leaves the to-less forms exactly as they were', () => {
+    for (const src of ['on click tell #modal show', 'tell #modal show']) {
+      const r = shapeOf(src);
+      expect(r.success, src).toBe(true);
+      expect(r.shape, src).toEqual(['tell', 'tell>show']);
+    }
+  });
+});
+
+describe('tell consumes its own `end` (defect 2)', () => {
+  it('keeps a post-end command inside an enclosing if — the measured divergence', () => {
+    // On main the leftover `end` closed the IF, so `log` escaped the
+    // conditional and ran unconditionally. Upstream keeps it inside.
+    const r = shapeOf('on click if true tell #modal show end log "x" end');
+    expect(r.success).toBe(true);
+    expect(r.errors).toBe(0);
+    expect(r.shape).toEqual(['if', 'if>tell', 'if>tell>show', 'if>log']);
+  });
+
+  it('keeps a post-end command inside an enclosing repeat', () => {
+    // On main `log` ran once, outside the loop; upstream runs it per-iteration.
+    const r = shapeOf('on click repeat 2 times tell #modal add .x end log "y" end');
+    expect(r.success).toBe(true);
+    expect(r.errors).toBe(0);
+    expect(r.shape).toEqual(['repeat', 'repeat>tell', 'repeat>tell>add', 'repeat>log']);
+  });
+
+  it('closes only the tell with a doubled end', () => {
+    const r = shapeOf('on click repeat 2 times tell #modal add .x end end');
+    expect(r.success).toBe(true);
+    expect(r.errors).toBe(0);
+    expect(r.shape).toEqual(['repeat', 'repeat>tell', 'repeat>tell>add']);
+  });
+
+  it('keeps the handler-level rows byte-identical to their old shape', () => {
+    // These absorbed the leftover `end` harmlessly before; consuming it in
+    // tell must not move anything.
+    const ROWS: Array<[string, string[]]> = [
+      ['on click tell #modal show end log "after"', ['tell', 'tell>show', 'log']],
+      ['on click tell #modal show end', ['tell', 'tell>show']],
+      ['tell #modal show end', ['tell', 'tell>show']],
+      ['on click tell #modal show then log "after"', ['tell', 'tell>show', 'tell>log']],
+    ];
+    for (const [src, expected] of ROWS) {
+      const r = shapeOf(src);
+      expect(r.success, src).toBe(true);
+      expect(r.errors, src).toBe(0);
+      expect(r.shape, src).toEqual(expected);
+    }
+  });
+
+  it('still leaves `else` for the enclosing if', () => {
+    const r = shapeOf('on click if true tell #modal show else log "no" end');
+    expect(r.success).toBe(true);
+    expect(r.shape).toEqual(['if', 'if>tell', 'if>tell>show', 'if>log']);
+  });
+});
+
+describe('the retarget executes for real', () => {
+  // The defect's damage was at runtime: the body ran against the WRONG element
+  // and nothing reported it. These run the fixed forms end to end — a parse
+  // that merely succeeds proves nothing (the broken form also "succeeded").
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="host"></div><div id="inner"></div>';
+  });
+
+  const host = () => document.getElementById('host') as HTMLElement;
+  const inner = () => document.getElementById('inner') as HTMLElement;
+
+  it('tell #inner to add .x lands on #inner, not on me', async () => {
+    await hyperscript.eval('tell #inner to add .x', host());
+    expect(inner().classList.contains('x'), 'the told element').toBe(true);
+    expect(host().classList.contains('x'), 'the handler element must NOT get it').toBe(false);
+  });
+
+  it('a then-joined body command also runs against the target', async () => {
+    await hyperscript.eval('tell #inner to add .a then add .b', host());
+    expect(inner().classList.contains('a')).toBe(true);
+    expect(inner().classList.contains('b')).toBe(true);
+    expect(host().classList.length).toBe(0);
+  });
+
+  it('a post-end command inside a conditional stays conditional', async () => {
+    // The defect-2 damage: on main the `add .escaped` ran even when the
+    // condition was false, because the leftover `end` closed the IF early.
+    await hyperscript.eval('if false tell #inner add .no end add .escaped to me end', host());
+    expect(inner().classList.contains('no')).toBe(false);
+    expect(host().classList.contains('escaped'), 'must stay inside the false branch').toBe(false);
+  });
+});

--- a/packages/core/src/parser/command-parsers/utility-commands.ts
+++ b/packages/core/src/parser/command-parsers/utility-commands.ts
@@ -723,6 +723,21 @@ export function parseTellCommand(ctx: ParserContext, identifierNode: IdentifierN
     throw new Error('tell command requires a target expression');
   }
 
+  // Optional `to` between target and body: `tell #modal to show`. Upstream
+  // REJECTS this form loudly (`Expected 'end' but found 'to'`), but hyperfixi
+  // cannot afford to throw here: inside a handler body,
+  // parseCommandWithErrorRecovery swallows any command-parser throw and the
+  // stranded body re-parses as top-level commands — so `on click tell #modal
+  // to show` parsed CLEAN with no tell node and `show` silently ran against
+  // the handler's `me` instead of #modal (the measured table in
+  // PARSER_NEXT_STEPS.md). Consuming the word honors the author's evident
+  // intent and is the only fix that cannot be silently un-fixed by the
+  // recovery machinery. Deliberate superset of upstream grammar, same as
+  // pick's legacy forms.
+  if (ctx.check(KEYWORDS.TO)) {
+    ctx.advance();
+  }
+
   // Parse the command(s) to execute on each target
   const commands: ASTNode[] = [];
 
@@ -757,16 +772,23 @@ export function parseTellCommand(ctx: ParserContext, identifierNode: IdentifierN
 
       // Check for control flow boundaries after parsing a command.
       //
-      // KNOWN GAP: breaking on `end` is all we do with it — `tell` never CONSUMES
-      // its terminator, so `tell #x add .a end` leaves the `end` in the stream for
-      // whatever encloses us (inside a handler it is taken as the handler's own
-      // `end`). Upstream REQUIRES the terminator: TellCommand.parse calls
-      // `requireToken("end")` unless it is already at a feature start, which means
-      // hyperfixi has no real `tell … end` block form, only this inline one.
-      // Closing that is a termination-semantics change, not a separator fix, so it
-      // was deliberately left out of the `then`-separator work above.
-      // Tracked in docs-internal/PARSER_NEXT_STEPS.md.
-      if (ctx.check(KEYWORDS.ELSE) || ctx.check(KEYWORDS.END)) {
+      // `else` belongs to an enclosing `if` — leave it. A directly-following
+      // `end` is tell's OWN terminator and is CONSUMED, matching upstream
+      // (TellCommand.parse calls `requireToken("end")` unless at a feature
+      // start). Merely breaking on it — the previous behavior — left the `end`
+      // for whatever enclosed us, which mis-attributed everything after it:
+      // `on click if true tell #modal show end log "x" end` gave the leftover
+      // `end` to the IF, so `log` escaped the conditional and ran
+      // unconditionally (upstream keeps it inside; same shape with `repeat`,
+      // where the trailing command ran once instead of per-iteration). At
+      // handler level the leftover was absorbed harmlessly, which is why the
+      // gap looked cosmetic when probed casually. Measured tables in
+      // docs-internal/PARSER_NEXT_STEPS.md.
+      if (ctx.check(KEYWORDS.ELSE)) {
+        break;
+      }
+      if (ctx.check(KEYWORDS.END)) {
+        ctx.advance();
         break;
       }
 


### PR DESCRIPTION
Closes both remaining `tell` rows from `PARSER_NEXT_STEPS.md` — the last two ungated entries in that document — and corrects a third stale row found while closing them.

## Defect 1: the silent retarget (the dangerous one)

`on click tell #modal to show` parsed with `success: true`, **zero errors, and no `tell` node** — `show` silently ran against the handler's `me` instead of `#modal`. The bare form failed loudly, which is exactly why the defect read as harmless when probed casually. The filed table reproduced verbatim on main.

**Why acceptance, not an error.** Upstream rejects the `to` form loudly (`Expected 'end' but found 'to'`, measured on the real hyperscript.org engine). But hyperfixi cannot throw its way to parity: `parseCommandWithErrorRecovery` swallows any command-parser throw inside handler bodies and lets the stranded body re-parse as top-level commands — **the throw was the silent-retarget mechanism**. Consuming an optional `to` after the target is the only fix the recovery machinery cannot un-fix, and is a deliberate superset of upstream grammar (pick's legacy-forms precedent). The bare form went from a loud failure to working.

## Defect 2: the leaked `end`

Re-measuring first showed the filed severity was **half-wrong in an interesting way**: at handler level the leftover `end` was absorbed harmlessly (every handler-level row already matched upstream structurally). The real damage was nested:

| Source | main | upstream |
| ------ | ---- | -------- |
| `on click if true tell #modal show end log "x" end` | `log` **escapes the if**, runs unconditionally | `end` closes the tell; `log` stays inside |
| `on click repeat 2 times tell #modal add .x end log "y" end` | `log` runs **once, outside the loop** | `log` runs per-iteration, inside |

`tell` now consumes a directly-following `end` (upstream's `requireToken("end")`); both nested shapes match upstream. One deliberate residue: a single `end` where two closings are needed (`if true tell #m show end log "x"`) now records a *recoverable* "Expected 'end' after if block" diagnostic while building the upstream-matching tree — stricter than upstream's silence about ambiguous source.

## Bonus: the `wait for click or 1s` row was stale

Re-measuring the queue's next item before implementing it showed it needed **no code**: PR #850 (`c74fb184`) already shipped duration alternatives in `parseWaitCommand`'s `for` loop, gated by `wait-event-or-duration.test.ts` — while the doc's table still listed the half as rejecting. Third stale filing caught by re-measurement in one day. The doc now strikes the row, and with it **every entry in PARSER_NEXT_STEPS.md's table is either FIXED or protected by a self-failing gate**.

## Verification

- **13-row behavioral gate** (`tell-to-and-end.test.ts`): structural tree assertions (who owns which command) — `success: true` is not evidence of a command, which is the trap that hid defect 1. Both halves **mutation-verified**: reverting the `to` consumption reddens 6 rows, the `end` consumption 3.
- **Execution rows**: the retarget lands on the told element end to end, including the conditional-escape case staying dormant under `if false`.
- **Blast radius measured**: branch-vs-main sweep of all 190 documented command examples (single-file swap) → **zero** parse-shape diffs. Full core suite 7942 green; root `test:check` (incl. shipped-sources + shipped-examples-execution gates) green; typecheck clean.
- Runtime untouched — `TellCommand`'s `args [target, ...commands]` contract is preserved.

## Noted, not fixed

`parseCommandWithErrorRecovery`'s throw-swallowing remains: any command parser that throws inside a handler body still degrades silently — `tell` was just its worst client. Recorded in `PARSER_NEXT_STEPS.md` as the place to start if another silent command-drop surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)