### PR TITLE
fix(semantic): take's recipient — the 10-language R1 tail was three parse bugs, not the rendering arc it was filed as

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -39,10 +39,15 @@
 >
 > Both were sized by a **whole-corpus pre/post probe** (3960 stored patterns.db
 > rows, 24 languages × the full pattern set) and both diffed to exactly their
-> target rows and nothing else. **Seven languages are now at avgRoleFidelity
-> 1.0000 — ar, de, es, fr, pt, sw, tl.** What remains: the 10
-> `take.recipient` rows (#864's named i18n-rendering follow-up) and 14
-> scattered singletons — the "thin and flat" headroom by design.
+> target rows and nothing else.
+>
+> **#874 then closed 9 of the 10 `take.recipient` rows** — and needed no
+> rendering change at all, which is the third time this arc's filed prescription
+> was falsified by triage. R1 tail **24 → 15**; **fourteen languages are now at
+> avgRoleFidelity 1.0000** — ar, bn, de, es, fr, hi, it, ja, pt, ru, sw, tl, tr,
+> uk. What remains: qu's `take.recipient` (blocked on a renderer defect, named
+> in that section) and 14 scattered singletons — the "thin and flat" headroom by
+> design.
 
 ## Where we are (2026-07-20 baseline `82fb5827` · post pick-text-range arc 3 · `browser-priority`)
 
@@ -2956,7 +2961,7 @@ The two headlines for this side:
   `for` was an unconsumed-tail artifact and the duration role removes it. The
   corpus row parses faithfully in all 24 and needs no allowlist entry.
 
-## ~~`take` has no `recipient` role — the en reference drops `for me`~~ — SHIPPED (2026-07-31), 10-language tail open
+## ~~`take` has no `recipient` role — the en reference drops `for me`~~ — SHIPPED (2026-07-31); the 10-language tail CLOSED to 1 (2026-08-01, #874)
 
 The en half is FIXED. `takeSchema` now declares a `recipient` role
 (`markerOverride: { en: 'for' }`, `expectedTypes: ['reference']`,
@@ -2998,6 +3003,56 @@ exactly 0.0013 of that language's avgRoleFidelity. Both the captured and
 deferred lists are pinned in `packages/semantic/test/take-recipient.test.ts`,
 so a language starting to capture is a visible test failure, not a silent
 drift: move it to CAPTURED and regenerate the baseline in the same change.
+
+### The 10-language tail — CLOSED to 1 (2026-08-01, #874)
+
+**The prescription this filing left behind was wrong in the same way its own
+two premises were.** The standing plan was per-language opt-in i18n rendering:
+retag the pronoun-valued `duration` phrase as `recipient` in the transformer,
+then author a marker particle and a `canonicalOrder` slot per opted-in profile,
+invert the `grammar.test.ts` assertions, and rewrite `ROLE_CATALOG`'s usage
+string. **None of that was needed. Not one line of rendering changed.** The
+surfaces were already right; triage found three unrelated PARSE-side causes,
+and the 10 were never one failure mode:
+
+| languages         | cause                                                                                     | fix                                  |
+| ----------------- | ----------------------------------------------------------------------------------------- | ------------------------------------ |
+| it, ru, uk, vi    | `patterns/get.ts` listed the language's TAKE verb among `get`'s alternatives                | remove the alternatives              |
+| bn, hi, ja, ko, tr | `generateSOVPatientFirstEventHandlerPattern` had no trailing recipient slot                | `appendOptionalRecipient`            |
+| qu                | canonical order fronts the source phrase — no pattern has that shape                       | deferred, see below                  |
+
+The first is much bigger than the role it was found through: `prendere .active
+da .tab-button io` (it), `взять …` (ru), `взяти …` (uk), `lấy …` (vi) returned a
+**`get`** at confidence 1.00. The tokenizers keep the two verbs distinct and the
+i18n transformer renders them distinctly, so those alternatives could never
+match a real `get` — they only shadowed `take`. The recipient loss was the
+downstream symptom: the fused event-handler swap re-parses
+`[verb..clause boundary]` standalone and swaps the richer result in only when it
+is the SAME action, so an action flip vetoed the swap.
+
+**qu is deferred, with its blocker named.** A source-fronted pattern variant
+fixes it — measured: qu's take row AND `event-from-elsewhere` both go
+role-faithful, two more rows gain confidence. But it then wins on qu's compound
+rows, where the flattened body loses its `then` connectives and
+`tabs-basic`/`tabs-content` stop reproducing the en DOM effect (**R2, tolerance
+0**). The blocker underneath predates this work: qu's `add .active to me`
+renders as `add .active` in both states — the destination is captured and then
+dropped by the renderer — so the emitted English is only unambiguous while a
+`then` separates it from the preceding command. **Fix the dropped destination
+first**; the pattern variant is a few lines after that.
+
+**A matcher defect found on the way, live in 90 shipped patterns.** Every
+`<cmd>-event-<lang>-sov` binds `destination` in BOTH a pre-verb and a post-verb
+optional group. `matchGroupToken`'s rollback restored the captured KEY set but
+not overwritten VALUES, so a trailing group that speculatively captured a token
+into an already-filled role and then failed its marker left the corruption
+behind: ja `クリック で #panel に .active を トグル ゴミ` returned
+`destination="ゴミ"` with the real `#panel` discarded. Fixed and pinned.
+
+Whole-corpus probe (3984 rows, pre vs post): **exactly the 9 take rows**, zero
+structural and zero confidence diffs elsewhere. Baseline: those 9 languages drop
+`take-class-from-siblings` from `roleLossyPatterns` and **seven reach
+avgRoleFidelity 1.0000** (bn, hi, it, ja, ru, tr, uk). R1 tail **24 → 15 rows**.
 
 `valueShape: 'reference'` is the second shape-anchor kind and it is
 load-bearing — **measured under mutation**: deleting it drops plain

--- a/packages/semantic/src/generators/event-handlers-sov.ts
+++ b/packages/semantic/src/generators/event-handlers-sov.ts
@@ -115,29 +115,87 @@ export function appendOptionalViewTransition(
   commandSchema: CommandSchema,
   languageCode: string
 ): void {
-  const mannerRole = commandSchema.roles.find(r => r.role === 'manner' && !r.required);
-  const marker = mannerRole?.markerOverride?.[languageCode];
-  if (!mannerRole || !marker) return;
+  appendOptionalTailRole(tokens, extraction, commandSchema, languageCode, 'manner', {
+    requireMarker: true,
+  });
+}
+
+/**
+ * Append an optional trailing `[{recipient}]` group to an event-handler pattern
+ * when the schema declares a non-required `recipient` role
+ * (`take .active from .tab-button for me`).
+ *
+ * Marker-LESS in 23 of 24 languages by design (`takeSchema.recipient` overrides
+ * only `en: 'for'`), because the i18n transformer renders the recipient as a
+ * BARE trailing pronoun everywhere — `… von .tab-button ich`, `… .tab-button
+ * থেকে আমি`. Safe as a marker-less trailing slot because the role is typed
+ * `['reference']` and shape-anchored on `'reference'`: only `me`/`you`/`it`/
+ * `result` can fill it, and the shape anchor keeps the uncaptured slot out of
+ * `scoreRoleCoverage`'s denominator.
+ *
+ * Without it, bn/hi/ja/ko/tr matched take at confidence 1.0 and reported
+ * `fused body walk left 1 token(s) unconsumed: "<pronoun>"` — five of the ten
+ * rows in the baseline's `roleLossyPatterns` for `take-class-from-siblings`.
+ * The other five were unrelated: it/ru/uk/vi had `get`'s hand-written pattern
+ * claiming take's verb (`patterns/get.ts`), and qu never matches a pattern at
+ * all.
+ */
+export function appendOptionalRecipient(
+  tokens: PatternToken[],
+  extraction: Record<string, ExtractionRule>,
+  commandSchema: CommandSchema,
+  languageCode: string
+): void {
+  appendOptionalTailRole(tokens, extraction, commandSchema, languageCode, 'recipient', {
+    requireMarker: false,
+  });
+}
+
+/**
+ * Shared body of the two appenders above: emit `[<marker words> {role}]` as a
+ * trailing optional group, with the marker (if any) and every type/shape knob
+ * read from the schema's own `RoleSpec`, so a generated event-handler pattern
+ * cannot drift from the command patterns' version of the same slot.
+ *
+ * `requireMarker` distinguishes the two cases: `manner` is reachable only
+ * behind its required `using view` literals and must not emit a bare slot,
+ * while `recipient` is marker-less in 23 languages and would never emit at all
+ * under that rule.
+ */
+function appendOptionalTailRole(
+  tokens: PatternToken[],
+  extraction: Record<string, ExtractionRule>,
+  commandSchema: CommandSchema,
+  languageCode: string,
+  role: SemanticRole,
+  opts: { requireMarker: boolean }
+): void {
+  const spec = commandSchema.roles.find(r => r.role === role && !r.required);
+  if (!spec) return;
+  const marker = spec.markerOverride?.[languageCode];
+  if (opts.requireMarker && !marker) return;
 
   tokens.push({
     type: 'group',
     optional: true,
     tokens: [
-      ...marker.split(/\s+/).map((word): PatternToken => ({ type: 'literal', value: word })),
+      ...(marker ? marker.split(/\s+/) : []).map(
+        (word): PatternToken => ({ type: 'literal', value: word })
+      ),
       {
         type: 'role',
-        role: 'manner',
+        role,
         optional: true,
-        expectedTypes: mannerRole.expectedTypes,
+        expectedTypes: spec.expectedTypes,
         // Load-bearing, same as on the generated command patterns: it exempts
-        // the trailing slot from the matcher's verb guard (`transition` is
-        // itself a command keyword) and normalizes the captured value type to
-        // the EN reference's `literal`.
-        ...(mannerRole.valueShape !== undefined ? { valueShape: mannerRole.valueShape } : {}),
+        // the trailing slot from the matcher's verb guard, keeps the uncaptured
+        // slot out of `scoreRoleCoverage`'s denominator, and (for `keyword`)
+        // normalizes the captured value type to the EN reference's `literal`.
+        ...(spec.valueShape !== undefined ? { valueShape: spec.valueShape } : {}),
       },
     ],
   });
-  extraction.manner = { fromRole: 'manner' };
+  extraction[role] = { fromRole: role };
 }
 
 /**
@@ -338,7 +396,10 @@ export function generateSOVPatientFirstEventHandlerPattern(
     ...(swapsOperands ? {} : eventHandlerDestinationExtraction(commandSchema)),
     ...eventHandlerSourceExtraction(commandSchema),
   };
-  // `using view transition` rides at the very end, after the with-marked operand.
+  // take's bare trailing pronoun, then `using view transition`, both at the very
+  // end — after the with-marked operand and after the source phrase, which is
+  // where the i18n transformer puts them in verb-final output.
+  appendOptionalRecipient(tokens, extraction, commandSchema, profile.code);
   appendOptionalViewTransition(tokens, extraction, commandSchema, profile.code);
 
   return {

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -2584,8 +2584,18 @@ export class PatternMatcher {
   ): boolean {
     const mark = tokens.mark();
 
-    // Track which roles were captured before this group
-    const capturedBefore = new Set(captured.keys());
+    // Snapshot the captured roles' VALUES, not just their keys. Clearing only
+    // the newly-added keys leaves an OVERWRITE by a failed group in place.
+    //
+    // 90 shipped patterns bind one role in TWO optional groups — every
+    // `<cmd>-event-<lang>-sov` has a pre-verb `[{destination} <marker>]` and a
+    // post-verb one, because the transformer emits the to-phrase on either side
+    // depending on the command. When the trailing group speculatively captures
+    // the next token into that role and then fails on its marker, the token
+    // stream rolls back but the corrupted value survives: ja
+    // `クリック で #panel に .active を トグル ゴミ` returned
+    // `destination="ゴミ"` with the real `#panel` captured and discarded.
+    const capturedBefore = new Map(captured);
 
     const success = this.matchTokenSequence(
       tokens,
@@ -2596,10 +2606,16 @@ export class PatternMatcher {
 
     if (!success) {
       tokens.reset(mark);
-      // Clear any roles that were partially captured during the failed group match
+      // Restore the pre-group capture state exactly: drop roles the failed group
+      // added, and put back the values it overwrote.
       for (const role of captured.keys()) {
         if (!capturedBefore.has(role)) {
           captured.delete(role);
+        }
+      }
+      for (const [role, value] of capturedBefore) {
+        if (captured.get(role) !== value) {
+          captured.set(role, value);
         }
       }
       return patternToken.optional || false;

--- a/packages/semantic/src/patterns/get.ts
+++ b/packages/semantic/src/patterns/get.ts
@@ -5,6 +5,22 @@
  * Languages without hand-crafted patterns rely on auto-generation from profiles.
  *
  * Phase 3.2: Consolidated from 13 files into single file.
+ *
+ * **A `get` verb alternative must never be another command's verb.** Five of
+ * these patterns listed the language's TAKE verb among `get`'s alternatives —
+ * it `prendere`, bn `নিন`, ru `взять`/`возьми`, uk `взяти`/`візьми`, vi `lấy` —
+ * so `take .active from .tab-button <pron>` matched `get-<l>-full` at
+ * confidence 1.00 and came back as a `get`. The tokenizers keep the two verbs
+ * distinct (`prendere`→take, `ottenere`→get) and the i18n transformer renders
+ * them distinctly, so the alternatives could never match a real `get` surface;
+ * they only shadowed take.
+ *
+ * The visible symptom was one role: the fused event-handler swap re-parses
+ * `[verb..clause boundary]` standalone and swaps the richer result in only when
+ * it is the SAME action, so an action flip vetoed the swap and take's trailing
+ * `recipient` pronoun dropped — it/ru/uk/vi's rows in the baseline's
+ * `roleLossyPatterns`. STANDALONE, those four returned the wrong command
+ * outright.
  */
 
 import type { LanguagePattern } from '../types';
@@ -22,7 +38,7 @@ function getGetPatternsBn(): LanguagePattern[] {
         tokens: [
           { type: 'role', role: 'source' },
           { type: 'literal', value: 'থেকে' },
-          { type: 'literal', value: 'পান', alternatives: ['নিন'] },
+          { type: 'literal', value: 'পান' },
         ],
       },
       extraction: {
@@ -38,7 +54,7 @@ function getGetPatternsBn(): LanguagePattern[] {
       template: {
         format: 'পান {source}',
         tokens: [
-          { type: 'literal', value: 'পান', alternatives: ['নিন'] },
+          { type: 'literal', value: 'পান' },
           { type: 'role', role: 'source' },
         ],
       },
@@ -125,7 +141,7 @@ function getGetPatternsIt(): LanguagePattern[] {
       template: {
         format: 'ottenere {patient} da {source}',
         tokens: [
-          { type: 'literal', value: 'ottenere', alternatives: ['ottieni', 'get', 'prendere'] },
+          { type: 'literal', value: 'ottenere', alternatives: ['ottieni', 'get'] },
           { type: 'role', role: 'patient' },
           {
             type: 'group',
@@ -217,7 +233,7 @@ function getGetPatternsRu(): LanguagePattern[] {
       template: {
         format: 'получить {patient} из {source}',
         tokens: [
-          { type: 'literal', value: 'получить', alternatives: ['получи', 'взять', 'возьми'] },
+          { type: 'literal', value: 'получить', alternatives: ['получи'] },
           { type: 'role', role: 'patient' },
           {
             type: 'group',
@@ -242,7 +258,7 @@ function getGetPatternsRu(): LanguagePattern[] {
       template: {
         format: 'получить {patient}',
         tokens: [
-          { type: 'literal', value: 'получить', alternatives: ['получи', 'взять', 'возьми'] },
+          { type: 'literal', value: 'получить', alternatives: ['получи'] },
           { type: 'role', role: 'patient' },
         ],
       },
@@ -285,7 +301,7 @@ function getGetPatternsUk(): LanguagePattern[] {
       template: {
         format: 'отримати {patient} з {source}',
         tokens: [
-          { type: 'literal', value: 'отримати', alternatives: ['отримай', 'взяти', 'візьми'] },
+          { type: 'literal', value: 'отримати', alternatives: ['отримай'] },
           { type: 'role', role: 'patient' },
           {
             type: 'group',
@@ -310,7 +326,7 @@ function getGetPatternsUk(): LanguagePattern[] {
       template: {
         format: 'отримати {patient}',
         tokens: [
-          { type: 'literal', value: 'отримати', alternatives: ['отримай', 'взяти', 'візьми'] },
+          { type: 'literal', value: 'отримати', alternatives: ['отримай'] },
           { type: 'role', role: 'patient' },
         ],
       },
@@ -331,7 +347,7 @@ function getGetPatternsVi(): LanguagePattern[] {
       template: {
         format: 'lấy giá trị của {target}',
         tokens: [
-          { type: 'literal', value: 'lấy giá trị', alternatives: ['nhận', 'lấy'] },
+          { type: 'literal', value: 'lấy giá trị', alternatives: ['nhận'] },
           { type: 'group', optional: true, tokens: [{ type: 'literal', value: 'của' }] },
           { type: 'role', role: 'patient' },
         ],
@@ -342,13 +358,17 @@ function getGetPatternsVi(): LanguagePattern[] {
     },
     {
       id: 'get-vi-simple',
+      // Head was `lấy` (alt `lấy giá trị`) — but bare `lấy` is vi's TAKE verb,
+      // so this pattern claimed every `lấy .active từ …`. vi's get verb is the
+      // three-word `lấy giá trị` ("take the value of"), which is what the i18n
+      // transformer renders; the bare form has no valid `get` surface.
       language: 'vi',
       command: 'get',
       priority: 90,
       template: {
-        format: 'lấy {target}',
+        format: 'lấy giá trị {target}',
         tokens: [
-          { type: 'literal', value: 'lấy', alternatives: ['nhận', 'lấy giá trị'] },
+          { type: 'literal', value: 'lấy giá trị', alternatives: ['nhận'] },
           { type: 'role', role: 'patient' },
         ],
       },

--- a/packages/semantic/test/take-recipient.test.ts
+++ b/packages/semantic/test/take-recipient.test.ts
@@ -174,45 +174,64 @@ describe('the reference anchor: what the slot refuses', () => {
  * Every one renders the recipient as a BARE trailing pronoun; only English
  * marks it (`for`).
  *
- * The split below is MEASURED, not chosen: a whole-corpus probe (3960 rows,
- * every pattern × every language, pre vs post) showed 14 languages capture the
- * pronoun into the marker-less slot and 10 leave it uncaptured, with zero
- * diffs anywhere else in the corpus. The 10 are the named R1 burn-down tail —
- * they appear in the baseline's `roleLossyPatterns` for this pattern. Moving a
- * language from DEFERRED to CAPTURED is the follow-up work; moving one the
- * other way is a regression.
+ * 23 of 24 capture, as of #874 (qu is the exception — see 3 below). The 10 that did not were the named R1 burn-down
+ * tail, and the standing filing prescribed the expensive fix — retag the
+ * pronoun-valued duration phrase as `recipient` in the i18n transformer, then
+ * author a per-language marker particle and a `canonicalOrder` slot in each
+ * profile. **None of that was needed.** The rendering was already correct in
+ * all 23 languages; triage found three unrelated parse-side causes:
+ *
+ * 1. **it/ru/uk/vi** — `patterns/get.ts` listed the language's TAKE verb among
+ *    `get`'s alternatives (it `prendere`, ru `взять`, uk `взяти`, vi `lấy`), so
+ *    the standalone re-parse the fused event-handler swap performs came back as
+ *    a `get`, and an action flip vetoes the swap. STANDALONE, those four
+ *    returned the wrong command outright — a strictly larger bug than the role.
+ * 2. **bn/hi/ja/ko/tr** — `generateSOVPatientFirstEventHandlerPattern` had no
+ *    trailing recipient slot (`appendOptionalRecipient` now adds it, the
+ *    `appendOptionalScope` shape).
+ * 3. **qu** — NOT fixed, and deliberately so. Its canonical order fronts the
+ *    source phrase (`.active ta .tab-button manta ñitiy pi hapiy noqa`), a
+ *    shape no pattern covers, so qu matches nothing and the verb-anchoring
+ *    fallback binds the pronoun to `destination`. A source-fronted pattern
+ *    variant DOES fix it (measured: qu take + `event-from-elsewhere` both go
+ *    role-faithful, two more rows gain confidence), but it then wins on qu's
+ *    compound rows, where the flattened body loses its `then` connectives and
+ *    `tabs-basic`/`tabs-content` stop reproducing the en DOM effect — an R2
+ *    failure at tolerance 0. The blocker underneath is a renderer defect that
+ *    predates this work: qu's `add .active to me` renders as `add .active` in
+ *    both states, so the emitted English is only unambiguous while a `then`
+ *    separates it from the preceding command. Fix the dropped destination
+ *    first; the pattern variant is a few lines after that.
+ *
+ * Moving a language out of CAPTURED is a regression.
  */
 const CAPTURED: Array<[string, string]> = [
   ['en', 'on click take .active from .tab-button for me'],
   ['ar', 'خذ .active من .tab-button عند نقر أنا'],
+  ['bn', '.active কে ক্লিক এ নিন .tab-button থেকে আমি'],
   ['de', 'bei klick nehmen .active von .tab-button ich'],
   ['es', 'en clic tomar .active de .tab-button yo'],
   ['fr', 'sur clic prendre .active de .tab-button moi'],
   ['he', 'ב לחיצה קח את .active מ .tab-button אני'],
-  ['id', 'pada klik ambil .active dari .tab-button saya'],
-  ['ms', 'apabila click ambil .active dari .tab-button saya'],
-  ['pl', 'gdy kliknięcie weź .active z .tab-button ja'],
-  ['pt', 'em clique pegar .active de .tab-button eu'],
-  ['sw', 'kwenye bonyeza chukua .active kutoka .tab-button mimi'],
-  ['th', 'เมื่อ คลิก รับ .active จาก .tab-button ฉัน'],
-  ['tl', 'kumuha .active mula_sa .tab-button kapag click ako'],
-  ['zh', '当 点击 时 拿取 把 .active 从 .tab-button 我'],
-];
-
-const DEFERRED: Array<[string, string]> = [
-  ['bn', '.active কে ক্লিক এ নিন .tab-button থেকে আমি'],
   ['hi', '.active को क्लिक पर लें .tab-button से मैं'],
+  ['id', 'pada klik ambil .active dari .tab-button saya'],
   ['it', 'su clic prendere .active da .tab-button io'],
   ['ja', '.active を クリック で 取る .tab-button から 私'],
   ['ko', '.active 를 클릭 할 때 가져오다 .tab-button 에서 나'],
-  ['qu', '.active ta .tab-button manta ñitiy pi hapiy noqa'],
+  ['ms', 'apabila click ambil .active dari .tab-button saya'],
+  ['pl', 'gdy kliknięcie weź .active z .tab-button ja'],
+  ['pt', 'em clique pegar .active de .tab-button eu'],
   ['ru', 'при клик взять .active из .tab-button я'],
+  ['sw', 'kwenye bonyeza chukua .active kutoka .tab-button mimi'],
+  ['th', 'เมื่อ คลิก รับ .active จาก .tab-button ฉัน'],
+  ['tl', 'kumuha .active mula_sa .tab-button kapag click ako'],
   ['tr', '.active i tıklama de tut .tab-button den ben'],
   ['uk', 'при клік взяти .active з .tab-button я'],
   ['vi', 'khi nhấp lấy .active từ .tab-button tôi'],
+  ['zh', '当 点击 时 拿取 把 .active 从 .tab-button 我'],
 ];
 
-describe('the corpus row, in the 14 languages that capture the recipient', () => {
+describe('the corpus row, in the 23 languages that capture the recipient', () => {
   it.each(CAPTURED)('%s binds recipient=me on a single take', (lang, source) => {
     const commands = walkCommands(parse(source, lang));
     expect(
@@ -226,20 +245,60 @@ describe('the corpus row, in the 14 languages that capture the recipient', () =>
   });
 });
 
-describe('the corpus row, in the 10 languages still deferred (R1 burn-down tail)', () => {
-  /**
-   * These pin the CURRENT measured state, not a desired one. Each still parses
-   * the take with both other roles intact — the slot's presence perturbs
-   * nothing (that is what "passive defer" means and why no per-language marker
-   * particle was added). A language starting to capture here is progress:
-   * move it up to CAPTURED and regenerate the baseline in the same change.
-   */
-  it.each(DEFERRED)('%s parses patient + source, recipient uncaptured', (lang, source) => {
+describe('the three causes behind the 10, pinned directly', () => {
+  it.each([
+    ['it', 'prendere .active da .tab-button io'],
+    ['ru', 'взять .active из .tab-button я'],
+    ['uk', 'взяти .active з .tab-button я'],
+    ['vi', 'lấy .active từ .tab-button tôi'],
+  ])('[%s] the STANDALONE take is a take, not a get', (lang, source) => {
+    // The cause behind these four, and strictly bigger than the missing role:
+    // `get`'s hand-written pattern listed take's verb as an alternative, so this
+    // surface came back as `get` at confidence 1.00 — which also vetoed the
+    // fused event-handler re-parse swap (same-action gated) and dropped the
+    // recipient in the corpus row above.
     const commands = walkCommands(parse(source, lang));
     expect(commands.map(c => c.action), `${lang}: "${source}"`).toEqual(['take']);
-    const node = commands[0] as unknown as CommandSemanticNode;
-    expect(roleValue(node, 'patient'), `${lang}: patient`).toBe('.active');
-    expect(roleValue(node, 'source'), `${lang}: source`).toBe('.tab-button');
-    expect(node.roles.has('recipient' as never), `${lang}: recipient`).toBe(false);
+  });
+
+  it.each([
+    ['it', 'ottenere #input.value'],
+    ['ru', 'получить #input.value'],
+    ['uk', 'отримати #input.value'],
+    ['vi', 'lấy giá trị #input.value'],
+    ['bn', '#input.value কে পান'],
+  ])('[%s] the real get verb still parses as a get (both-ways negative)', (lang, source) => {
+    // The alternatives were removed, not renamed: every language's own `get`
+    // surface — what the i18n transformer actually renders — must keep working.
+    expect(walkCommands(parse(source, lang)).map(c => c.action), `${lang}`).toEqual(['get']);
+  });
+
+  it('qu still binds the pronoun to destination — the one language not fixed', () => {
+    // Pinning the CURRENT measured state and its cause, not a desired one: qu
+    // matches no pattern for this surface (its canonical order fronts the source
+    // phrase), so verb-anchoring assigns the trailing pronoun. See the header
+    // for why the pattern variant that fixes it is blocked on a renderer defect.
+    const node = walkCommands(
+      parse('.active ta .tab-button manta ñitiy pi hapiy noqa', 'qu')
+    )[0] as unknown as CommandSemanticNode;
+    expect(roleValue(node, 'patient')).toBe('.active');
+    expect(roleValue(node, 'source')).toBe('.tab-button');
+    expect(node.roles.has('recipient' as never)).toBe(false);
+    expect(roleValue(node, 'destination')).toBe('me');
+  });
+
+  it('a failed optional group cannot corrupt an already-captured role', () => {
+    // Not a take defect — a matcher one, found while probing qu and live in 90
+    // shipped patterns: every `<cmd>-event-<lang>-sov` binds `destination` in
+    // BOTH a pre-verb and a post-verb optional group. The trailing group
+    // speculatively captures the next token into that role, fails on its marker,
+    // and the rollback restored the captured KEY set but not overwritten VALUES.
+    // Mutation-verified: without the value restore this returns
+    // `destination="ゴミ"` — the junk tail — with the real `#panel` discarded.
+    const node = walkCommands(
+      parse('クリック で #panel に .active を トグル ゴミ', 'ja')
+    ).find(c => c.action === 'toggle') as unknown as CommandSemanticNode;
+    expect(roleValue(node, 'destination')).toBe('#panel');
+    expect(roleValue(node, 'patient')).toBe('.active');
   });
 });

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-08-01T18:39:30.922Z",
-  "commit": "b935b352",
+  "timestamp": "2026-08-01T19:11:38.421Z",
+  "commit": "fa3a1890",
   "languages": {
     "ar": {
       "parseSuccess": 156,
@@ -17,7 +17,7 @@
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [],
-      "bundleSize": 559400,
+      "bundleSize": 559592,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -653,16 +653,14 @@
       "avgFidelity": 1,
       "avgPrecision": 0.997863247863248,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9987096774193549,
+      "avgRoleFidelity": 1,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "take-class-from-siblings"
-      ],
-      "bundleSize": 559400,
+      "roleLossyPatterns": [],
+      "bundleSize": 559592,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1305,7 +1303,7 @@
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [],
-      "bundleSize": 559400,
+      "bundleSize": 559592,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1938,7 +1936,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 559400,
+      "bundleSize": 559592,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2581,7 +2579,7 @@
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [],
-      "bundleSize": 559400,
+      "bundleSize": 559592,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3224,7 +3222,7 @@
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [],
-      "bundleSize": 559400,
+      "bundleSize": 559592,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3869,7 +3867,7 @@
       "roleLossyPatterns": [
         "set-attribute"
       ],
-      "bundleSize": 559400,
+      "bundleSize": 559592,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4505,16 +4503,14 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9987096774193549,
+      "avgRoleFidelity": 1,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "take-class-from-siblings"
-      ],
-      "bundleSize": 559400,
+      "roleLossyPatterns": [],
+      "bundleSize": 559592,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5161,7 +5157,7 @@
         "fetch-error-handling",
         "fetch-json"
       ],
-      "bundleSize": 559400,
+      "bundleSize": 559592,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5797,16 +5793,14 @@
       "avgFidelity": 1,
       "avgPrecision": 0.997863247863248,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9987096774193549,
+      "avgRoleFidelity": 1,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "take-class-from-siblings"
-      ],
-      "bundleSize": 559400,
+      "roleLossyPatterns": [],
+      "bundleSize": 559592,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6442,16 +6436,14 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9987096774193549,
+      "avgRoleFidelity": 1,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "take-class-from-siblings"
-      ],
-      "bundleSize": 559400,
+      "roleLossyPatterns": [],
+      "bundleSize": 559592,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7087,18 +7079,17 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.995483870967742,
+      "avgRoleFidelity": 0.9967741935483871,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [
-        "take-class-from-siblings",
         "when-multiple-changes",
         "when-value-changes"
       ],
-      "bundleSize": 559400,
+      "bundleSize": 559592,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7743,7 +7734,7 @@
       "roleLossyPatterns": [
         "hide-with-transition"
       ],
-      "bundleSize": 559400,
+      "bundleSize": 559592,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8388,7 +8379,7 @@
       "roleLossyPatterns": [
         "unless-condition"
       ],
-      "bundleSize": 559400,
+      "bundleSize": 559592,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9031,7 +9022,7 @@
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [],
-      "bundleSize": 559400,
+      "bundleSize": 559592,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9678,7 +9669,7 @@
         "on-custom-event-receive",
         "take-class-from-siblings"
       ],
-      "bundleSize": 559400,
+      "bundleSize": 559592,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10314,16 +10305,14 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9987096774193549,
+      "avgRoleFidelity": 1,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "take-class-from-siblings"
-      ],
-      "bundleSize": 559400,
+      "roleLossyPatterns": [],
+      "bundleSize": 559592,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10966,7 +10955,7 @@
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [],
-      "bundleSize": 559400,
+      "bundleSize": 559592,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11611,7 +11600,7 @@
       "roleLossyPatterns": [
         "toggle-aria-expanded"
       ],
-      "bundleSize": 559400,
+      "bundleSize": 559592,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12254,7 +12243,7 @@
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [],
-      "bundleSize": 559400,
+      "bundleSize": 559592,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12890,16 +12879,14 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9987096774193549,
+      "avgRoleFidelity": 1,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "take-class-from-siblings"
-      ],
-      "bundleSize": 559400,
+      "roleLossyPatterns": [],
+      "bundleSize": 559592,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13535,16 +13522,14 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9987096774193549,
+      "avgRoleFidelity": 1,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "take-class-from-siblings"
-      ],
-      "bundleSize": 559400,
+      "roleLossyPatterns": [],
+      "bundleSize": 559592,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14180,17 +14165,16 @@
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9974193548387098,
+      "avgRoleFidelity": 0.9987096774193549,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [
-        "its-value-possessive-dot",
-        "take-class-from-siblings"
+        "its-value-possessive-dot"
       ],
-      "bundleSize": 559400,
+      "bundleSize": 559592,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14836,7 +14820,7 @@
         "repeat-forever",
         "repeat-until-event"
       ],
-      "bundleSize": 559400,
+      "bundleSize": 559592,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15467,7 +15451,7 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 559400,
+      "size": 559592,
       "languages": [
         "en",
         "es",


### PR DESCRIPTION
#864 named this the i18n-rendering follow-up. All 23 non-en corpus surfaces render `take .active from .tab-button for me`'s recipient as a BARE trailing pronoun, 14 languages captured it and 10 did not, and the standing plan was per-language opt-in **rendering** — retag the pronoun-valued `duration` phrase as `recipient` in the transformer, then author a marker particle and a `canonicalOrder` slot per opted-in profile, invert `grammar.test.ts`'s assertions, rewrite `ROLE_CATALOG`'s usage string.

**Not one line of rendering changed.** The surfaces were already correct. The 10 were never one failure mode — triage found three unrelated PARSE-side causes, and each was cheaper than the plan for all ten.

| languages | cause | fix |
| --- | --- | --- |
| it, ru, uk, vi | `patterns/get.ts` listed the language's TAKE verb among `get`'s alternatives | remove the alternatives |
| bn, hi, ja, ko, tr | `generateSOVPatientFirstEventHandlerPattern` had no trailing recipient slot | `appendOptionalRecipient` |
| qu | canonical order fronts the source phrase — no pattern has that shape | deferred, blocker named |

### 1. it/ru/uk/vi — `get` was claiming `take`'s verb

it `prendere`, ru `взять`/`возьми`, uk `взяти`/`візьми`, vi `lấy`. This is much bigger than the role it was found through: `prendere .active da .tab-button io` came back as a **`get`** at confidence 1.00, standalone. The tokenizers keep the two verbs distinct (`prendere`→take, `ottenere`→get) and the i18n transformer renders them distinctly, so those alternatives could never match a real `get` surface — they only shadowed take.

The recipient loss was the downstream symptom: the fused event-handler swap re-parses `[verb..clause boundary]` standalone and swaps the richer result in only when it is the SAME action, so an action flip vetoed the swap.

### 2. bn/hi/ja/ko/tr — no trailing recipient slot

They matched take at 1.0 while reporting `fused body walk left 1 token(s) unconsumed: "<pronoun>"`. `appendOptionalRecipient` is the `appendOptionalScope`/`appendOptionalViewTransition` shape; all three now share one helper that reads every knob off the schema's own `RoleSpec`, so a generated event-handler slot cannot drift from the command patterns' version. Marker-less is safe here because the role is typed `['reference']` and shape-anchored — only `me`/`you`/`it`/`result` can fill it.

### 3. qu — DEFERRED, with its blocker named

Its canonical order fronts the source phrase (`.active ta .tab-button manta ñitiy pi hapiy noqa`), a shape no pattern covers, so qu matches nothing and verb-anchoring binds the pronoun to `destination`.

A source-fronted pattern variant DOES fix it (measured: qu's take row **and** `event-from-elsewhere` both go role-faithful, two more rows gain confidence) — but it then wins on qu's compound rows, where the flattened body loses its `then` connectives and `tabs-basic`/`tabs-content` stop reproducing the en DOM effect. **R2 caught that at tolerance 0, and the whole-corpus probe did not** — its action SET contains both commands either way.

The blocker underneath predates this work: qu's `add .active to me` renders as `add .active` in both states, so the emitted English is only unambiguous while a `then` separates it from the preceding command. Fix the dropped destination first.

### A matcher defect found on the way, live in 90 shipped patterns

Every `<cmd>-event-<lang>-sov` binds `destination` in BOTH a pre-verb and a post-verb optional group. `matchGroupToken`'s rollback restored the captured KEY set but not overwritten VALUES, so a trailing group that speculatively captured a token into an already-filled role and then failed its marker left the corruption behind. Mutation-verified: ja `クリック で #panel に .active を トグル ゴミ` returns `destination="ゴミ"` with the real `#panel` discarded.

## Measured, not argued

Whole-corpus probe over every stored patterns.db row (3984): the diff is **EXACTLY the 9 take rows** — zero structural and zero confidence diffs elsewhere.

The first attempt at qu is why that probe records confidence at all: widening the existing patient-first pattern instead of adding a variant dropped ~90 rows' confidence across all six SOV languages (`remove-element` 0.886 → 0.822 everywhere, `ko fetch-json` 0.778 → 0.636, crossing the 0.7 adoption threshold) **with no structural diff at all**.

All three halves independently mutation-verified: reverting `get.ts` reddens exactly it/ru/uk/vi (8 rows — the recipient AND the standalone action); reverting `appendOptionalRecipient` reddens exactly bn/hi/ja/ko/tr; reverting the group rollback reddens the ja destination row.

## Baseline

Those 9 languages drop `take-class-from-siblings` from `roleLossyPatterns`; **zero pattern rows changed**, no parse-rate / R0 / precision / multiset / value / R2 / R4 / R5 movement.

**R1 tail 24 → 15 rows; fourteen languages now at avgRoleFidelity 1.0000** (ar bn de es fr hi it ja pt ru sw tl tr uk — up from seven).

## Gates

multilingual `--regression` green (all 11 signals) · `test:canonical` 7/7, both allowlists still EMPTY · semantic 7662 · root `test:check` all packages · vocab consistency 0 unwaived · hyperscript-adapter 209 · typecheck + lint clean. All re-run after rebasing onto #873.

No schema, profile, dictionary, tokenizer or i18n edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)