### PR TITLE
feat(semantic): `morph … using view transition` — the third schema with the tail, and the last

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -3116,10 +3116,19 @@ languages, added with the corpus row in #873.
 
 **Still open, deliberately** (both filed rather than folded in):
 
-- **`morph` has the identical tail and the identical gap.** `MorphCommand`
-  shares swap's arg scan and would work the same way, but `morphSchema` declares
-  no `manner` role, so seeding the modifier read there would be unreachable
-  code. Same fix, same size, one more schema.
+- ~~**`morph` has the identical tail and the identical gap.**~~ — **SHIPPED
+  (2026-08-01, #875).** `morphSchema` carries the shared
+  `VIEW_TRANSITION_MANNER_ROLE` (svo/sov 3) + `ast.modifiers.viewTransition`,
+  and `MorphCommand.parseInput` reads the modifier alongside its flat-args
+  scan. Simpler than swap was: morph has NO hand-written patterns in any
+  language, so the schema role is the whole pattern-side fix — 23/24 languages
+  round-trip byte-identically (`test/view-transition-manner.test.ts`). The one
+  deferral is **ms**, whose possessive fold eats `ia using` into a
+  property-path on the tail form only (plain form clean) — the same ms defect
+  family as its process deferral, pinned in the same file. Whole-corpus probe:
+  zero structural and zero confidence diffs (no corpus row carries the morph
+  tail). The mapper-parity fixture and the ast-shape exemption list both gained
+  their morph entries (intentional-AST-change branch of each oracle).
 - ~~**The corpus row + i18n rendering.**~~ — **SHIPPED (2026-08-01, #873).** The
   transformer masks the tail before any splitting/translation and re-appends it
   verbatim at the clause end (`maskViewTransitionTails`, the `maskCaretScopes`

--- a/packages/core/docs/commands/REFERENCE.md
+++ b/packages/core/docs/commands/REFERENCE.md
@@ -999,6 +999,10 @@ morph <target> with <content>
 morph over <target> with <content>
 ```
 
+```hyperscript
+morph <target> with <content> using view transition
+```
+
 **Examples:**
 
 ```hyperscript

--- a/packages/core/docs/commands/commands.json
+++ b/packages/core/docs/commands/commands.json
@@ -383,7 +383,11 @@
     },
     "morph": {
       "description": "Morph content into target elements (intelligent diffing, preserves state)",
-      "syntax": ["morph <target> with <content>", "morph over <target> with <content>"],
+      "syntax": [
+        "morph <target> with <content>",
+        "morph over <target> with <content>",
+        "morph <target> with <content> using view transition"
+      ],
       "examples": ["morph #target with it", "morph over #modal with fetchedContent"],
       "sideEffects": ["dom-mutation"],
       "category": "dom",

--- a/packages/core/src/commands/dom/__tests__/morph.test.ts
+++ b/packages/core/src/commands/dom/__tests__/morph.test.ts
@@ -200,6 +200,36 @@ describe('MorphCommand (Standalone V2)', () => {
       expect(input.useViewTransition).toBe(true);
     });
 
+    it('honours a viewTransition modifier (the shape morphSchema\'s manner role emits)', async () => {
+      // The semantic path binds `using view transition` to morphSchema's
+      // `manner` role and delivers it as `modifiers.viewTransition` — the flat
+      // three-keyword args above are the TRADITIONAL parser's shape only.
+      // Before the modifier read, every semantic-path morph silently dropped
+      // the animation request (same gap SwapCommand closed in #870).
+      const element = createTestElement('<div id="animated">Original</div>');
+      testElements.push(element);
+      const context = createMockContext(element);
+
+      const targetNode = mockSelector('#animated');
+      const withNode = mockIdentifier('with');
+      const contentNode = mockLiteral('<div>Updated</div>');
+      const valueMap = new Map<ASTNode, unknown>([
+        [targetNode, '#animated'],
+        [contentNode, '<div>Updated</div>'],
+      ]);
+
+      const input = await command.parseInput(
+        {
+          args: [targetNode, withNode, contentNode],
+          modifiers: { viewTransition: mockLiteral('transition') as never },
+        },
+        inlineEvaluator(valueMap),
+        context
+      );
+
+      expect(input.useViewTransition).toBe(true);
+    });
+
     it('should fallback to positional args when no keywords present', async () => {
       const element = createTestElement('<div id="fallback">Original</div>');
       testElements.push(element);

--- a/packages/core/src/commands/dom/swap.ts
+++ b/packages/core/src/commands/dom/swap.ts
@@ -200,9 +200,8 @@ export class SwapCommand implements DecoratedCommand {
     // it as `modifiers.viewTransition` — presence is the whole request (the
     // role's captured value is just the literal word `transition`). The
     // traditional parser leaves the three keywords in the arg list instead,
-    // which the scan below reads. MorphCommand has the same tail and the same
-    // arg scan, but morphSchema declares no `manner` role, so seeding it there
-    // too would be unreachable — filed in MULTILINGUAL_NEXT_STEPS.md.
+    // which the scan below reads. MorphCommand reads both the same way, off
+    // morphSchema's own `manner` role.
     let useViewTransition = raw.modifiers?.viewTransition !== undefined;
     if (usingIndex !== -1) {
       const afterUsing = argKeywords.slice(usingIndex + 1);
@@ -376,7 +375,11 @@ export class SwapCommand implements DecoratedCommand {
 export class MorphCommand implements DecoratedCommand {
   static readonly metadata = commandMeta({
     description: 'Morph content into target elements (intelligent diffing, preserves state)',
-    syntax: ['morph <target> with <content>', 'morph over <target> with <content>'],
+    syntax: [
+      'morph <target> with <content>',
+      'morph over <target> with <content>',
+      'morph <target> with <content> using view transition',
+    ],
     examples: ['morph #target with it', 'morph over #modal with fetchedContent'],
     sideEffects: ['dom-mutation'],
     category: 'dom',
@@ -416,8 +419,13 @@ export class MorphCommand implements DecoratedCommand {
     const overIndex = argKeywords.findIndex(k => k === 'over');
     const usingIndex = argKeywords.findIndex(k => k === 'using');
 
-    // Check for 'using view transition' modifier
-    let useViewTransition = false;
+    // Check for 'using view transition' modifier. Two arrival shapes, same as
+    // SwapCommand: the semantic path binds the tail to morphSchema's `manner`
+    // role and emits `modifiers.viewTransition` (presence is the whole
+    // request); the traditional parser — which owns English, morph being on
+    // SKIP_SEMANTIC_COMMANDS — leaves the three keywords in the arg list for
+    // the scan below.
+    let useViewTransition = raw.modifiers?.viewTransition !== undefined;
     if (usingIndex !== -1) {
       const afterUsing = argKeywords.slice(usingIndex + 1);
       if (afterUsing.includes('view') && afterUsing.includes('transition')) {

--- a/packages/hyperscript-adapter/src/generated/syntax-table.ts
+++ b/packages/hyperscript-adapter/src/generated/syntax-table.ts
@@ -43,7 +43,7 @@ export const SYNTAX: Record<string, readonly [string, string][]> = {
   log: [['patient', '']],
   make: [['patient', '']],
   measure: [['patient', ''], ['source', 'of']],
-  morph: [['patient', ''], ['destination', 'to']],
+  morph: [['patient', ''], ['destination', 'to'], ['manner', 'using view']],
   on: [['event', ''], ['source', 'from']],
   open: [['patient', ''], ['style', 'as']],
   pick: [['patient', ''], ['source', 'from']],

--- a/packages/semantic/src/generators/command-schemas.ts
+++ b/packages/semantic/src/generators/command-schemas.ts
@@ -3116,7 +3116,15 @@ export const morphSchema: CommandSchema = {
   primaryRole: 'patient',
   // `morph #list to it` → args [content], modifiers { on: element }.
   // Content is source or destination; the element being morphed is the patient.
-  ast: { args: [['source', 'destination']], modifiers: { on: 'patient' } },
+  //
+  // `manner` rides as `modifiers.viewTransition`, same as swap/process —
+  // MorphCommand.parseInput reads it for presence alongside its existing
+  // flat-args `using`/`view`/`transition` scan (the traditional-parser path,
+  // which owns English because morph sits on SKIP_SEMANTIC_COMMANDS).
+  ast: {
+    args: [['source', 'destination']],
+    modifiers: { on: 'patient', viewTransition: 'manner' },
+  },
   roles: [
     {
       role: 'patient',
@@ -3135,6 +3143,18 @@ export const morphSchema: CommandSchema = {
       svoPosition: 2,
       sovPosition: 2,
       markerOverride: { en: 'to' }, // "morph #target to it"
+    },
+    {
+      // `morph #target to it using view transition` — the same tail as swap and
+      // process, closed here for the same reason (#870's third-schema filing):
+      // without the role the semantic parser matched morph at confidence 1.0
+      // and stranded the tail, so every semantic-only consumer (multilingual
+      // bundles, the bridge, `translate()`) silently dropped the animation
+      // request in all 24 languages. Morph has NO hand-written patterns in any
+      // language, so this schema role is the whole fix on the pattern side.
+      ...VIEW_TRANSITION_MANNER_ROLE,
+      svoPosition: 3,
+      sovPosition: 3,
     },
   ],
 };

--- a/packages/semantic/test/ast-shape-consistency.test.ts
+++ b/packages/semantic/test/ast-shape-consistency.test.ts
@@ -96,6 +96,13 @@ const EXEMPTIONS: Record<string, { kind: ExemptionKind; reason: string }> = {
       '`raw.modifiers?.viewTransition` for presence, while the manner role is marked by the ' +
       'phrase `using view` — marker and modifier name cannot coincide here',
   },
+  'morph.viewTransition': {
+    kind: 'contract',
+    reason:
+      'Same contract key as swap/process, third schema with the tail: MorphCommand.parseInput ' +
+      'reads `raw.modifiers?.viewTransition` for presence alongside its flat-args scan, while ' +
+      'the manner role is marked by the phrase `using view`',
+  },
 };
 
 /** All roles of a first-present-of chain (a bare role is a one-role chain). */

--- a/packages/semantic/test/fixtures/mapper-parity.json
+++ b/packages/semantic/test/fixtures/mapper-parity.json
@@ -5050,7 +5050,7 @@
       ]
     },
     "morph": {
-      "roles": ["patient", "destination", "source"],
+      "roles": ["patient", "destination", "source", "manner"],
       "cases": [
         {
           "name": "no-roles",
@@ -5078,6 +5078,10 @@
               "type": "selector",
               "value": "#source-v",
               "selectorKind": "id"
+            },
+            "manner": {
+              "type": "literal",
+              "value": "manner-v"
             }
           },
           "ast": {
@@ -5097,6 +5101,10 @@
                 "value": ".patient-v",
                 "selector": ".patient-v",
                 "selectorType": "class"
+              },
+              "viewTransition": {
+                "type": "literal",
+                "value": "manner-v"
               }
             }
           }
@@ -5136,6 +5144,10 @@
               "type": "selector",
               "value": "#source-v",
               "selectorKind": "id"
+            },
+            "manner": {
+              "type": "literal",
+              "value": "manner-v"
             }
           },
           "ast": {
@@ -5148,7 +5160,13 @@
                 "selector": "#source-v",
                 "selectorType": "id"
               }
-            ]
+            ],
+            "modifiers": {
+              "viewTransition": {
+                "type": "literal",
+                "value": "manner-v"
+              }
+            }
           }
         },
         {
@@ -5185,6 +5203,10 @@
               "type": "selector",
               "value": "#source-v",
               "selectorKind": "id"
+            },
+            "manner": {
+              "type": "literal",
+              "value": "manner-v"
             }
           },
           "ast": {
@@ -5204,6 +5226,10 @@
                 "value": ".patient-v",
                 "selector": ".patient-v",
                 "selectorType": "class"
+              },
+              "viewTransition": {
+                "type": "literal",
+                "value": "manner-v"
               }
             }
           }
@@ -5242,6 +5268,10 @@
               "type": "selector",
               "value": "#destination-v",
               "selectorKind": "id"
+            },
+            "manner": {
+              "type": "literal",
+              "value": "manner-v"
             }
           },
           "ast": {
@@ -5252,6 +5282,70 @@
                 "type": "selector",
                 "value": "#destination-v",
                 "selector": "#destination-v",
+                "selectorType": "id"
+              }
+            ],
+            "modifiers": {
+              "on": {
+                "type": "selector",
+                "value": ".patient-v",
+                "selector": ".patient-v",
+                "selectorType": "class"
+              },
+              "viewTransition": {
+                "type": "literal",
+                "value": "manner-v"
+              }
+            }
+          }
+        },
+        {
+          "name": "only-manner",
+          "roles": {
+            "manner": {
+              "type": "literal",
+              "value": "manner-v"
+            }
+          },
+          "ast": {
+            "type": "command",
+            "name": "morph",
+            "args": [],
+            "modifiers": {
+              "viewTransition": {
+                "type": "literal",
+                "value": "manner-v"
+              }
+            }
+          }
+        },
+        {
+          "name": "without-manner",
+          "roles": {
+            "patient": {
+              "type": "selector",
+              "value": ".patient-v",
+              "selectorKind": "class"
+            },
+            "destination": {
+              "type": "selector",
+              "value": "#destination-v",
+              "selectorKind": "id"
+            },
+            "source": {
+              "type": "selector",
+              "value": "#source-v",
+              "selectorKind": "id"
+            }
+          },
+          "ast": {
+            "type": "command",
+            "name": "morph",
+            "args": [
+              {
+                "type": "selector",
+                "value": "#source-v",
+                "selector": "#source-v",
                 "selectorType": "id"
               }
             ],
@@ -5342,6 +5436,10 @@
                 "value": ".patient-v",
                 "selector": ".patient-v",
                 "selectorType": "class"
+              },
+              "viewTransition": {
+                "type": "literal",
+                "value": "manner-v"
               }
             }
           }

--- a/packages/semantic/test/view-transition-manner.test.ts
+++ b/packages/semantic/test/view-transition-manner.test.ts
@@ -77,8 +77,8 @@ function commandNode(source: string, lang: string, action: string): CommandSeman
   return hits[0] as unknown as CommandSemanticNode;
 }
 
-describe('both schemas declare the shape-anchored manner role', () => {
-  it.each(['swap', 'process'])('%s binds the tail to modifiers.viewTransition', action => {
+describe('all three schemas declare the shape-anchored manner role', () => {
+  it.each(['swap', 'process', 'morph'])('%s binds the tail to modifiers.viewTransition', action => {
     const schema = getSchema(action as never);
     const manner = schema?.roles.find(r => r.role === 'manner');
 
@@ -96,10 +96,10 @@ describe('both schemas declare the shape-anchored manner role', () => {
   });
 
   it('keeps the flag default-free — presence IS the request', () => {
-    // A default would emit `viewTransition` on every parse, so every swap and
-    // every process would animate. Same "absent means absent" rule #859 applied
-    // to take's source and #864 to its recipient.
-    for (const action of ['swap', 'process'] as const) {
+    // A default would emit `viewTransition` on every parse, so every swap,
+    // every process and every morph would animate. Same "absent means absent"
+    // rule #859 applied to take's source and #864 to its recipient.
+    for (const action of ['swap', 'process', 'morph'] as const) {
       expect(getSchema(action)?.roles.find(r => r.role === 'manner')?.default).toBeUndefined();
     }
   });
@@ -117,6 +117,7 @@ describe('both schemas declare the shape-anchored manner role', () => {
 describe('the English reference no longer drops the tail', () => {
   const EN_TAIL_FORMS: Array<[string, string]> = [
     ['process', 'process partials in it using view transition'],
+    ['morph', 'morph #list to it using view transition'],
     ['swap', 'swap #a with #b using view transition'],
     ['swap', 'swap innerHTML of #t with "<p>x</p>" using view transition'],
     ['swap', 'swap into #t with it using view transition'],
@@ -146,6 +147,7 @@ describe('the English reference no longer drops the tail', () => {
     for (const [plainSrc, tailSrc] of [
       ['process partials in it', 'process partials in it using view transition'],
       ['swap #a with #b', 'swap #a with #b using view transition'],
+      ['morph #list to it', 'morph #list to it using view transition'],
     ] as const) {
       const plain = buildAST(parse(plainSrc, 'en') as CommandSemanticNode).ast as any;
       const tail = buildAST(parse(tailSrc, 'en') as CommandSemanticNode).ast as any;
@@ -260,6 +262,28 @@ describe('the swap tail round-trips in 23 of 24 languages', () => {
   });
 });
 
+const MORPH_DEFERRED = new Set([
+  // ms folds `ia using` into a possessive property-path on the tail form only
+  // (destination becomes `its`, renders `morph #list to its using`); the plain
+  // form binds destination=it cleanly. The exact defect family as ms's process
+  // deferral above — the tail's own bug, not a pre-existing one.
+  'ms',
+]);
+
+describe('the morph tail round-trips in 23 of 24 languages', () => {
+  const enNode = parse('morph #list to it using view transition', 'en') as CommandSemanticNode;
+
+  it.each(LANGS.filter(l => !MORPH_DEFERRED.has(l)))('%s', lang => {
+    const surface = render(enNode, lang as never) as string;
+    const node = commandNode(surface, lang, 'morph');
+
+    expect(roleValue(node, 'patient'), `${lang}: "${surface}" patient`).toBe('#list');
+    expect(roleValue(node, 'destination'), `${lang}: "${surface}" destination`).toBe('it');
+    expect(roleValue(node, 'manner'), `${lang}: "${surface}" manner`).toBe('transition');
+    expect(unconsumedSpans(surface, lang), `${lang}: unconsumed`).toEqual([]);
+  });
+});
+
 describe('the process tail round-trips in 22 of 24 languages', () => {
   const enNode = parse('process partials in it using view transition', 'en') as CommandSemanticNode;
 
@@ -282,6 +306,16 @@ describe('the deferred rows, pinned as measured', () => {
 
   it('qu cannot parse the plain process form either — not this role', () => {
     expect(() => parse('chay partials in rurariy', 'qu')).toThrow();
+  });
+
+  it('ms morph: the plain form is clean; the tail form property-path-folds the destination', () => {
+    // Pinning the CURRENT state, not a desired one — if the ms possessive fold
+    // stops eating `ia using`, both rows flip and ms moves to CAPTURED above.
+    const plain = commandNode('ubah_bentuk #list ke ia', 'ms', 'morph');
+    expect(roleValue(plain, 'destination')).toBe('it');
+    const tail = commandNode('ubah_bentuk #list ke ia using view transition', 'ms', 'morph');
+    expect(tail.roles.get('destination' as never)?.type).toBe('property-path');
+    expect(tail.roles.has('manner' as never)).toBe(false);
   });
 });
 

--- a/packages/testing-framework/vocab-waivers.json
+++ b/packages/testing-framework/vocab-waivers.json
@@ -256,10 +256,6 @@
     "reason": "Batch 4: schema-override↔render alignment queued (NEXT_STEPS) — `fetch .. as json` consumes `as` as a handcrafted/generated pattern literal (matched by raw token.value, Batch 1 V4 probe mechanism), so parsing works; V2's parse-side union only sees roleMarkers/schema markers, not pattern literals."
   },
   {
-    "key": "V2|en|duration:for",
-    "reason": "Batch 4: schema-override↔render alignment queued (NEXT_STEPS) — duration `for` is consumed as a pattern literal (same mechanism as method:as); V2 cannot see pattern literals."
-  },
-  {
     "key": "V1|vi|reset",
     "reason": "V3c burn-down 2026-07-14: dictionary events.reset is deliberate English passthrough — the native đặt-lại hyphen-shatters on the parse side (round-trip probe re-parsed it as `put`), the broken-listener class. The profile verb stays native for command contexts; same profile-vs-events-passthrough class as the waived ar/sw/tl reset rows (Batch 3, blocked — no candidate round-trips)."
   },


### PR DESCRIPTION
#870 closed the `using view transition` gap for swap and process and filed morph as "same fix, same size, one more schema." Re-measured before building — for once, a filing that aged TRUE, and slightly generous: morph is **simpler** than swap was, because morph has no hand-written patterns in any language, so the schema role is the whole pattern-side fix (swap needed its four en hand patterns edited too).

Two halves, the swap/process shape exactly:

### 1. `morphSchema`

Spreads the shared `VIEW_TRANSITION_MANNER_ROLE` (svo/sov position 3) and maps `ast.modifiers.viewTransition: 'manner'`. Before it, the semantic parser matched `morph #list to it using view transition` at confidence 1.0 and stranded the tail — so every semantic-only consumer (multilingual bundles, the bridge, `translate()`) silently dropped the animation request in all 24 languages. English was never affected: morph sits on `SKIP_SEMANTIC_COMMANDS`, so the traditional parser (whose flat-args scan already read the tail) owns it there.

### 2. `MorphCommand.parseInput`

Now initializes `useViewTransition` from `raw.modifiers?.viewTransition !== undefined`, exactly as SwapCommand does — the modifier is how the semantic path delivers the role, the flat-args scan is the traditional path's shape.

## Measured

Round-trips in all 24 languages: **23 capture with byte-identical English round-trips**. The one deferral is **ms**, whose possessive fold eats `ia using` into a property-path on the tail form only (`ubah_bentuk #list ke ia` is clean; add the tail and destination becomes `its`) — the same ms defect family as its existing process deferral, pinned as measured.

Both halves independently mutation-verified: deleting the schema role reddens 27 rows; reverting the modifier read reddens the new core parseInput row. (The first schema mutation attempt left a syntax error and reported ZERO failures — the suite had failed to load, not passed — so both counts are from clean mutations with failure totals read off the summary line, not a grep.)

Whole-corpus probe (3984 stored rows, pre vs post): **zero structural and zero confidence diffs** — no corpus row carries the morph tail, and the marker-guarded optional group is inert everywhere else (the #873 confidence exemption already covers the event-handler patterns morph's group now appears in).

## Oracles

Two consistency gates fired, both taken on their intentional-change branch with the diff confined to morph:

- `mapper-parity.json` regenerated — morph gains `manner` in its measured role list; **zero other actions moved**
- `ast-shape-consistency` exemptions gain `morph.viewTransition` (same contract-key-vs-grammar-marker reason as swap/process)

The generated hyperscript-adapter syntax table restaged one line (`morph: … ['manner', 'using view']`). `MorphCommand.metadata` + generated command docs document the tail form, as swap's already did.

## Also: the stale `V2|en|duration:for` vocab waiver removed

Advisory-stale since #858, flagged by the CLI as matching no finding ("remove them"); the #864 brief said check-don't-force, and the check passes: 138 waived errors before and after, zero unwaived, no stale warnings.

## Gates

multilingual `--regression` green (all 11 signals, baseline untouched) · semantic 7693 · core 7943 incl. `verify:reference` + `docs:commands:check` · hyperscript-adapter 209 · vocab consistency 0 unwaived · whole-corpus probe zero-diff · typecheck clean. No profile, dictionary, tokenizer or i18n edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)