### PR TITLE
feat(community): GitHub-native intake for native-speaker translation review

### DIFF
--- a/.github/ISSUE_TEMPLATE/reviewer-application.yml
+++ b/.github/ISSUE_TEMPLATE/reviewer-application.yml
@@ -1,0 +1,67 @@
+name: Language Reviewer Application
+description: Volunteer as a native-speaker reviewer for one of LokaScript's 24 languages
+title: '[reviewer]: '
+labels: ['community-review', 'reviewer-application']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        LokaScript lets developers write hyperscript in their own language. The machine
+        gates prove the translations are *structurally* faithful — the right commands,
+        the right roles — but nothing yet proves they are *natural*, and the maintainer
+        does not read most of the 24 languages. That gap is what reviewers close.
+
+        **What reviewers do:** read the generated vocabulary and pattern translations for
+        their language and say what a developer there would actually write. Corrections
+        land as ordinary pull requests; your judgment on naturalness is final — nobody
+        overrules it, because nobody else can.
+
+        **What reviewers get:** credit by name on lokascript.org, an honorarium, and —
+        for educators — free lokascript-learn classroom seats.
+
+        **Time:** a first pass over one language's core vocabulary is a couple of hours.
+        After that it is occasional, as new patterns land.
+
+        You do not need to apply to help. Anyone can file a
+        [Translation](?template=translation-suggestion.yml) or
+        [Vocabulary](?template=vocabulary-suggestion.yml) suggestion, or 👍 someone
+        else's. Apply if you would like to take a language on properly.
+
+  - type: input
+    id: langs
+    attributes:
+      label: Which language(s)?
+      description: |
+        Native or near-native only, please — this is a judgment call about idiom, not
+        about comprehension. Note the variety if it matters (pt-BR vs pt-PT, zh-Hans vs
+        zh-Hant).
+      placeholder: pt (Brazilian)
+    validations:
+      required: true
+
+  - type: input
+    id: github
+    attributes:
+      label: How should we credit you?
+      description: |
+        Name or handle as you would like it shown on the site. Leave blank to be
+        credited by your GitHub username, or write "anonymous" to skip credit.
+
+  - type: textarea
+    id: background
+    attributes:
+      label: Background
+      description: |
+        Enough to show you write software in this language's ecosystem — where you work
+        or study, what you build, any localization or teaching experience. A couple of
+        sentences is plenty; no CV needed.
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Anything else?
+      description: |
+        What drew you to this, terms you already know are wrong, questions about the
+        program — whatever is useful.

--- a/.github/ISSUE_TEMPLATE/reviewer-application.yml
+++ b/.github/ISSUE_TEMPLATE/reviewer-application.yml
@@ -16,8 +16,9 @@ body:
         land as ordinary pull requests; your judgment on naturalness is final — nobody
         overrules it, because nobody else can.
 
-        **What reviewers get:** credit by name on lokascript.org, an honorarium, and —
-        for educators — free lokascript-learn classroom seats.
+        **What reviewers get:** credit by name on lokascript.org, and final say on
+        what reads naturally in their language. If you would want something else to
+        make this worth your time, say so below — that is a fair thing to ask.
 
         **Time:** a first pass over one language's core vocabulary is a couple of hours.
         After that it is occasional, as new patterns land.

--- a/.github/ISSUE_TEMPLATE/translation-suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/translation-suggestion.yml
@@ -1,0 +1,92 @@
+name: Translation Suggestion
+description: Suggest a more natural translation for a hyperscript pattern
+title: '[i18n]: '
+labels: ['community-review', 'translations']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Pattern translations are **generated** — by grammar transformation or keyword
+        substitution — and have not been reviewed by native speakers. If one reads
+        stiff, unidiomatic, or plain wrong, this form is where to say so.
+
+        Browse the patterns at [lokascript.org/patterns](https://lokascript.org/patterns/);
+        the "suggest a better translation" link there fills this form in for you.
+
+        For a wrong *word* rather than a wrong sentence, use the
+        [Vocabulary Suggestion](?template=vocabulary-suggestion.yml) form instead.
+
+  - type: input
+    id: pattern
+    attributes:
+      label: Pattern ID
+      description: Shown on the pattern card, e.g. `toggle-class-click`.
+      placeholder: toggle-class-click
+    validations:
+      required: true
+
+  - type: dropdown
+    id: lang
+    attributes:
+      label: Language
+      description: |
+        ISO code of the translation. ar Arabic · bn Bengali · de German · en English ·
+        es Spanish · fr French · he Hebrew · hi Hindi · id Indonesian · it Italian ·
+        ja Japanese · ko Korean · ms Malay · pl Polish · pt Portuguese · qu Quechua ·
+        ru Russian · sw Swahili · th Thai · tl Tagalog · tr Turkish · uk Ukrainian ·
+        vi Vietnamese · zh Chinese
+      options:
+        - ar
+        - bn
+        - de
+        - en
+        - es
+        - fr
+        - he
+        - hi
+        - id
+        - it
+        - ja
+        - ko
+        - ms
+        - pl
+        - pt
+        - qu
+        - ru
+        - sw
+        - th
+        - tl
+        - tr
+        - uk
+        - vi
+        - zh
+    validations:
+      required: true
+
+  - type: textarea
+    id: current
+    attributes:
+      label: Current translation
+      description: What the site renders today.
+      render: text
+
+  - type: textarea
+    id: suggested
+    attributes:
+      label: Suggested translation
+      description: How it should read instead.
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why is this better?
+      description: |
+        Register, idiom, word order, a mistranslated keyword — whatever makes the
+        current version wrong. This is the part we cannot work out for ourselves.
+      placeholder: |
+        「時」 here reads stiff for a UI label; 「で」 is what a developer would write.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/vocabulary-suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/vocabulary-suggestion.yml
@@ -1,0 +1,98 @@
+name: Vocabulary Suggestion
+description: Suggest a better word for a LokaScript keyword, role marker, or event name
+title: '[vocab]: '
+labels: ['community-review', 'vocabulary']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        LokaScript's vocabulary — the keyword for each command, the particles and
+        prepositions that mark roles, and the event names — is generated per language
+        and largely unreviewed by native speakers. One wrong word affects every pattern
+        that uses it, so this form is the highest-leverage kind of correction.
+
+        Browse the vocabulary at
+        [lokascript.org/community/vocabulary](https://lokascript.org/community/vocabulary/);
+        the per-row "suggest" link fills this form in for you.
+
+        For a sentence that reads wrong even though its words are right, use the
+        [Translation Suggestion](?template=translation-suggestion.yml) form instead.
+
+  - type: input
+    id: concept
+    attributes:
+      label: Concept
+      description: |
+        The English concept name from the vocabulary table — a command (`toggle`), a
+        role (`patient`), or an event (`click`).
+      placeholder: toggle
+    validations:
+      required: true
+
+  - type: dropdown
+    id: lang
+    attributes:
+      label: Language
+      description: |
+        ISO code. ar Arabic · bn Bengali · de German · en English · es Spanish ·
+        fr French · he Hebrew · hi Hindi · id Indonesian · it Italian · ja Japanese ·
+        ko Korean · ms Malay · pl Polish · pt Portuguese · qu Quechua · ru Russian ·
+        sw Swahili · th Thai · tl Tagalog · tr Turkish · uk Ukrainian · vi Vietnamese ·
+        zh Chinese
+      options:
+        - ar
+        - bn
+        - de
+        - en
+        - es
+        - fr
+        - he
+        - hi
+        - id
+        - it
+        - ja
+        - ko
+        - ms
+        - pl
+        - pt
+        - qu
+        - ru
+        - sw
+        - th
+        - tl
+        - tr
+        - uk
+        - vi
+        - zh
+    validations:
+      required: true
+
+  - type: input
+    id: current
+    attributes:
+      label: Current form
+      description: |
+        The word we use today. Alternatives are shown as `primary (alt1|alt2)` — paste
+        the cell as-is if you like.
+      placeholder: 切り替え
+
+  - type: input
+    id: suggested
+    attributes:
+      label: Suggested form
+      description: |
+        The word that should be used. If several are acceptable, give the best one
+        first, separated by `|`.
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why is this better?
+      description: |
+        Is the current word a false friend, the wrong register, a noun where a verb is
+        needed, a rare synonym? Say what a developer in your language would actually
+        expect to type.
+    validations:
+      required: true

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -4018,15 +4018,47 @@ handler-head family.
 Re-baseline (`--save-baseline`) after each intentional fidelity change, regenerate against a
 freshly `populate`d DB, and commit only the dicts/profiles + baseline (not `patterns.db`).
 
-## Community review system (designed 2026-07-20, not yet built)
+## Community review — intake simplified to GitHub-native (decided 2026-08-01)
 
-The machine gates prove structure; naturalness/idiom needs native-speaker + LLM-agent
-review. The full design — tier model (anonymous flags → OAuth proposers → trusted
-per-language reviewers whose edits skip triage → founder merge), hash-pinned
-"verified by native speakers" badges that auto-invalidate on regeneration,
-git-committed ledgers under `packages/patterns-reference/data/review/`, agent
-sweep/triage harness, changeset fan-out across the five vocab surfaces, glossary =
-`vocab dump`, and a 3-stage rollout on the lokascript-docs site — lives in
-**[proposals/community-review-system.md](proposals/community-review-system.md)**.
-Targets the business plan's Days 46–90 `/community` window; builds on
-`apps/profile-editor` (apply path) and the vocab CLI (glossary/browser data).
+The machine gates prove structure; naturalness/idiom needs native-speaker review, and
+the maintainer does not read most of the 24 languages. The full design lives in
+**[proposals/community-review-system.md](proposals/community-review-system.md)**
+(2026-07-20).
+
+**Decision (2026-08-01): GitHub Issues replace the proposal's custom intake service.**
+Deleted from scope, not deferred: the Fly volume, `community.db`, hand-rolled GitHub
+OAuth + sessions, invite tokens, the write API, the admin triage UI, the NDJSON export
+cursor, and `pull.ts`. Structured intake is three issue forms on the public repo;
+endorsement is a 👍 reaction; the review queue is
+`is:open label:community-review`; spam, identity, and rate-limiting are GitHub's
+problem. The proposal's T0 anonymous category-flag tier is dropped outright — it was
+already scoped to counters-only as "founder-hours poison", and the audience has GitHub
+accounts. The trust invariant (§10) is unchanged and now enforced by construction:
+nothing reaches `main` except a maintainer-merged PR through the full CI gate.
+
+Shipped 2026-08-01 (verify: `ls .github/ISSUE_TEMPLATE/` — three `*-suggestion.yml` /
+`reviewer-application.yml` forms; `gh label list | grep community-review`):
+
+- `translation-suggestion.yml`, `vocabulary-suggestion.yml`, `reviewer-application.yml`,
+  each carrying the `community-review` label. **Their field `id`s are a public API** —
+  the docs site deep-links with `?template=X.yml&<id>=<value>` prefill, so renaming an
+  id silently breaks every generated link. The `lang` dropdown options are **bare ISO
+  codes** for the same reason (issue-form dropdown prefill is exact-match).
+- Labels `community-review` / `translations` / `vocabulary` / `reviewer-application`
+  created on the repo. GitHub silently drops template labels that do not exist, so
+  these are load-bearing, not decoration.
+
+Site side (separate repo `_hyper_min`, `sites/lokascript-docs`, ships on merge to its
+`main`; verify: `curl -sI https://lokascript.org/community/ | head -1`): `/community/`
+landing + reviewer CTA, `/community/vocabulary/{lang}/` browser generated from
+`vocab dump`, and translation provenance (`translation_method` · `confidence` ·
+"unverified") plus per-row suggest links on `/patterns/`. All build-time static — no
+auth, no runtime writes, no server routes.
+
+Still deferred, designs in the proposal and unchanged by this decision: hash-pinned
+"verified by native speakers" badges, the `verifications.json` / `vocab-verifications.json`
+ledgers under `packages/patterns-reference/data/review/`, `verified_native*` columns +
+the `sync-translations` ledger join, the shared text-hash util, the agent sweep/triage
+harness, changeset fan-out across the five vocab surfaces, and the per-language status
+ladder. The badge work is the natural next arc: it is what turns "unverified" on the
+site into a claim, and it needs a real inflow of reviewer sign-offs first.

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -4055,6 +4055,17 @@ landing + reviewer CTA, `/community/vocabulary/{lang}/` browser generated from
 "unverified") plus per-row suggest links on `/patterns/`. All build-time static — no
 auth, no runtime writes, no server routes.
 
+**Reviewer incentives are UNSTATED on both public surfaces, deliberately (2026-08-01).**
+The proposal's §2 lists "credit, honorarium, free lokascript-learn classroom seats for
+educators" as already-defined and binding, citing
+`~/projects/ideas/lokascript-business-plan-2026-07.md` — **that file is not on disk**, so
+the honorarium and the seats are commitments no surviving document supports. Both were
+drafted onto the landing page and the application form and then removed before merge; the
+pages now promise only credit by name and final say on naturalness, and invite applicants
+to name what they would want. Do not re-add either from the proposal's wording alone —
+it is a citation to a missing source, not a decision record. Restore them if and only if
+the owner confirms.
+
 Still deferred, designs in the proposal and unchanged by this decision: hash-pinned
 "verified by native speakers" badges, the `verifications.json` / `vocab-verifications.json`
 ledgers under `packages/patterns-reference/data/review/`, `verified_native*` columns +

--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -4056,15 +4056,17 @@ landing + reviewer CTA, `/community/vocabulary/{lang}/` browser generated from
 auth, no runtime writes, no server routes.
 
 **Reviewer incentives are UNSTATED on both public surfaces, deliberately (2026-08-01).**
-The proposal's §2 lists "credit, honorarium, free lokascript-learn classroom seats for
-educators" as already-defined and binding, citing
-`~/projects/ideas/lokascript-business-plan-2026-07.md` — **that file is not on disk**, so
-the honorarium and the seats are commitments no surviving document supports. Both were
-drafted onto the landing page and the application form and then removed before merge; the
-pages now promise only credit by name and final say on naturalness, and invite applicants
-to name what they would want. Do not re-add either from the proposal's wording alone —
-it is a citation to a missing source, not a decision record. Restore them if and only if
-the owner confirms.
+The proposal's §2 lists three as already-defined and binding — credit, an honorarium, and
+free seats in a sibling teaching product — citing
+`~/projects/ideas/lokascript-business-plan-2026-07.md`. **That file is not on disk**, so
+the latter two are commitments of money and product that no surviving document supports.
+Both were drafted onto the landing page and the application form and then removed before
+merge, on two separate grounds: the citation is missing, and the owner considers the
+teaching product not ready to be named publicly (2026-08-01). The pages now promise only
+credit by name and final say on naturalness, and invite applicants to name what they would
+want instead. Do not re-add either from the proposal's wording alone — it is a citation to
+a missing source, not a decision record. Restore only on the owner's word, and treat the
+teaching product as unannounced until they say otherwise.
 
 Still deferred, designs in the proposal and unchanged by this decision: hash-pinned
 "verified by native speakers" badges, the `verifications.json` / `vocab-verifications.json`

--- a/docs-internal/proposals/community-review-system.md
+++ b/docs-internal/proposals/community-review-system.md
@@ -6,6 +6,18 @@ commits to the reviewer program and "verified by native speakers" badges but spe
 UI, flows, or tiers — this document is that spec).
 **Date:** 2026-07-20.
 
+> **Update (2026-08-01) — intake simplified, read this first.** Owner decision: GitHub
+> Issues replace the custom intake service. **Superseded** — §3's auth/tier mechanics
+> (OAuth implementation, invite tokens, the T0 anonymous-flag tier), §4's `community.db`
+> on a Fly volume, §7's site-hosted queue/admin UI and `pull.ts` materialization, and
+> §11 Stage 2 in full. Suggestions are now issue forms
+> (`.github/ISSUE_TEMPLATE/{translation,vocabulary}-suggestion.yml`,
+> `reviewer-application.yml`), endorsement is a 👍 reaction, and the queue is
+> `label:community-review`. **Still the reference, unchanged:** §5 addressing/hashes,
+> §6 badges as a pure function of ledger × current render, §7b agent sweeps, §8
+> changeset fan-out, §9 the glossary gate and language ladder, §10 the trust invariant.
+> Decision record and current status: `MULTILINGUAL_NEXT_STEPS.md` § Community review.
+
 ## 1. Context & goals
 
 Multilingual pattern/vocab quality now depends on review the founder cannot do alone:


### PR DESCRIPTION
## What

Three GitHub issue forms + the four labels they depend on, and the decision record that says why the approved design shrank.

- `translation-suggestion.yml` — a rendered pattern reads wrong (ids: `pattern`, `lang`, `current`, `suggested`, `why`)
- `vocabulary-suggestion.yml` — a keyword / role marker / event name is the wrong word (ids: `concept`, `lang`, `current`, `suggested`, `why`)
- `reviewer-application.yml` — volunteer to own a language (ids: `langs`, `github`, `background`, `motivation`)

## Why this instead of the design

`docs-internal/proposals/community-review-system.md` specced a custom intake service: Fly volume, `community.db`, hand-rolled GitHub OAuth, sessions, invite tokens, a write API, an admin triage UI, an NDJSON export cursor, `pull.ts`. GitHub Issues does all of it. Endorsement is a 👍; the queue is [`label:community-review`](https://github.com/codetalcott/hyperfixi/issues?q=is%3Aissue+is%3Aopen+label%3Acommunity-review); spam and identity are GitHub's problem. The proposal's anonymous-flag tier is dropped — it was already scoped to counters-only as "founder-hours poison", and the audience has GitHub accounts.

The trust invariant (proposal §10) is unchanged and now holds by construction: nothing reaches `main` except a maintainer-merged PR through the full CI gate. Badges, ledgers, agent sweeps, and changeset fan-out stay deferred with their designs intact.

## Two things that will bite if changed casually

**Field ids are a public API.** The docs site deep-links `?template=X.yml&<id>=<value>`; renaming an id breaks every generated link silently — the form just opens blank.

**The `lang` dropdown holds bare ISO codes** (`ja`, not `ja — 日本語`) because issue-form dropdown prefill is exact-match on option text.

## Labels

`community-review`, `translations`, `vocabulary`, `reviewer-application` are created on the repo already. GitHub silently drops template labels that don't exist, so without them the forms would file unlabeled issues into an empty-looking queue.

## Merge order

This merges **before** the docs-site PR (separate repo, `_hyper_min`) — the site's suggest links 404 to the template chooser until these YAMLs are on `main`.

## Test plan

- [x] YAML parses; field ids match the ones the site will emit
- [x] `prettier --check` clean
- [ ] After merge: open a prefill URL and confirm the dropdown and textareas arrive filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)