### PR TITLE
fix(semantic): wave-2 event vocabulary for tr and fr — noun primaries and the blur false friend

### DIFF
--- a/packages/semantic/src/generators/profiles/french.ts
+++ b/packages/semantic/src/generators/profiles/french.ts
@@ -99,7 +99,9 @@ export const frenchProfile: LanguageProfile = {
     trigger: { primary: 'déclencher', normalized: 'trigger' },
     send: { primary: 'envoyer', alternatives: ['envoie'], normalized: 'send' },
     focus: { primary: 'focaliser', alternatives: ['concentrer'], normalized: 'focus' },
-    blur: { primary: 'défocaliser', normalized: 'blur' },
+    // `défocaliser` is an unattested infinitive; French pedagogy writes
+    // `perte de focus` for the event (2026-07 terminology review).
+    blur: { primary: 'perte de focus', alternatives: ['défocaliser'], normalized: 'blur' },
     // Phase 1 (v0.9.90): DOM / form state / debug
     // `vide` (adjective, "empty") is the i18n transformer's `is empty` predicate
     // form; `vider` is the verb ("to empty"). Accept both so the emptiness check
@@ -112,7 +114,13 @@ export const frenchProfile: LanguageProfile = {
     reset: { primary: 'réinitialiser', alternatives: ['reinitialiser'], normalized: 'reset' },
     breakpoint: { primary: 'point-arrêt', alternatives: ['point-arret'], normalized: 'breakpoint' },
     go: { primary: 'aller', alternatives: ['naviguer', 'va'], normalized: 'go' },
-    scroll: { primary: 'défiler', alternatives: ['faire-défiler'], normalized: 'scroll' },
+    // MDN fr and the OQLF standardize the noun `défilement` for the event; the
+    // infinitive stays as an alternative.
+    scroll: {
+      primary: 'défilement',
+      alternatives: ['defilement', 'défiler', 'faire-défiler'],
+      normalized: 'scroll',
+    },
     push: { primary: 'pousser', normalized: 'push' },
     replace: { primary: 'remplacer', normalized: 'replace' },
     process: { primary: 'traiter', normalized: 'process' },
@@ -178,9 +186,15 @@ export const frenchProfile: LanguageProfile = {
     after: { primary: 'après', normalized: 'after' },
     // Common event names (for event handler patterns)
     click: { primary: 'clic', alternatives: ['clique'], normalized: 'click' },
-    // `resize` event (window-resize): dict emits redimensionner; register it so the
-    // event types as literal="resize" (matching en) instead of expression.
-    resize: { primary: 'redimensionner', normalized: 'resize' },
+    // `resize` event (window-resize): the noun `redimensionnement` is the
+    // attested event form ("lors du redimensionnement de la fenêtre"). The dict
+    // still emits redimensionner, kept as an alternative so the event keeps
+    // typing as literal="resize" (matching en) instead of expression.
+    resize: {
+      primary: 'redimensionnement',
+      alternatives: ['redimensionner'],
+      normalized: 'resize',
+    },
     hover: { primary: 'survol', alternatives: ['survoler'], normalized: 'hover' },
     submit: { primary: 'soumission', alternatives: ['soumettre'], normalized: 'submit' },
     input: { primary: 'saisie', alternatives: ['entrée'], normalized: 'input' },

--- a/packages/semantic/src/generators/profiles/turkish.ts
+++ b/packages/semantic/src/generators/profiles/turkish.ts
@@ -123,9 +123,17 @@ export const turkishProfile: LanguageProfile = {
     on: { primary: 'üzerinde', alternatives: ['zaman'], normalized: 'on' },
     trigger: { primary: 'tetikle', normalized: 'trigger' },
     send: { primary: 'gönder', normalized: 'send' },
-    // DOM focus
-    focus: { primary: 'odak', alternatives: ['odaklanma'], normalized: 'focus' },
-    blur: { primary: 'bulanık', alternatives: ['bulanıklık', 'bulanik'], normalized: 'blur' },
+    // DOM focus. `odaklanma` (the act of focusing) leads over the static state
+    // noun `odak` — Turkish event prose says "odaklanma olayı". `bulanık` was
+    // the optical blur (CSS filters, image processing), never the DOM event;
+    // native usage is `odak kaybı` (loss of focus). 2026-07 terminology-review
+    // corrections; old forms stay as parse alternatives.
+    focus: { primary: 'odaklanma', alternatives: ['odak'], normalized: 'focus' },
+    blur: {
+      primary: 'odak kaybı',
+      alternatives: ['odak kaybi', 'bulanık', 'bulanıklık', 'bulanik'],
+      normalized: 'blur',
+    },
     // Phase 1 (v0.9.90): DOM / form state / debug
     empty: { primary: 'boşalt', alternatives: ['bosalt', 'boş'], normalized: 'empty' },
     open: { primary: 'aç', alternatives: ['ac'], normalized: 'open' },
@@ -146,7 +154,9 @@ export const turkishProfile: LanguageProfile = {
     },
     hover: { primary: 'üzerine gelme', alternatives: ['üzerinde gezinme'], normalized: 'hover' },
     submit: { primary: 'gönderme', normalized: 'submit' },
-    input: { primary: 'giriş', alternatives: ['girdi', 'giris'], normalized: 'input' },
+    // `giriş` reads as entry/login (giriş yapma) and can imply an auth event;
+    // the data-input term is `girdi` ("Girdi (Input) Eventleri").
+    input: { primary: 'girdi', alternatives: ['giriş', 'giris'], normalized: 'input' },
     change: { primary: 'değişiklik', alternatives: ['değişim', 'degisim'], normalized: 'change' },
     // `load` event: the i18n dict emits yükle for `load`. Without this keyword the
     // SOV reorder's mid-stream `yükle de` (on load) tokenized as the `install`
@@ -156,7 +166,13 @@ export const turkishProfile: LanguageProfile = {
     load: { primary: 'yükle', normalized: 'load' },
     // Navigation
     go: { primary: 'git', normalized: 'go' },
-    scroll: { primary: 'kaydır', alternatives: ['kaydir'], normalized: 'scroll' },
+    // `kaydır` is the bare imperative; the attested event noun is `kaydırma`
+    // ("kaydırma olayı"). The imperative stays as an alternative.
+    scroll: {
+      primary: 'kaydırma',
+      alternatives: ['kaydirma', 'kaydır', 'kaydir'],
+      normalized: 'scroll',
+    },
     push: { primary: 'itele', alternatives: ['push'], normalized: 'push' },
     replace: { primary: 'değiştir_url', alternatives: ['degistir_url'], normalized: 'replace' },
     process: { primary: 'işle', alternatives: ['isle'], normalized: 'process' },

--- a/packages/semantic/src/parser/generated/language-grammar.ts
+++ b/packages/semantic/src/parser/generated/language-grammar.ts
@@ -397,6 +397,8 @@ export const KEYWORD_LANGUAGE_MAP: Record<string, readonly string[]> = {
   décrémenter: ['fr'],
   default: ['en', 'tl'],
   défaut: ['fr'],
+  defilement: ['fr'],
+  défilement: ['fr'],
   défiler: ['fr'],
   defina: ['pt'],
   definieren: ['de'],
@@ -921,7 +923,9 @@ export const KEYWORD_LANGUAGE_MAP: Record<string, readonly string[]> = {
   'kawsay-pukyu': ['qu'],
   kaydet: ['tr'],
   kaydir: ['tr'],
+  kaydirma: ['tr'],
   kaydır: ['tr'],
+  kaydırma: ['tr'],
   kaykamaqa: ['qu'],
   kaypi: ['qu'],
   kazdy: ['pl'],
@@ -1201,6 +1205,8 @@ export const KEYWORD_LANGUAGE_MAP: Record<string, readonly string[]> = {
   ocultar: ['es', 'pt'],
   od: ['pl'],
   odak: ['tr'],
+  'odak kaybi': ['tr'],
+  'odak kaybı': ['tr'],
   odaklanma: ['tr'],
   odskup: ['pl'],
   oeffnen: ['de'],
@@ -1280,6 +1286,7 @@ export const KEYWORD_LANGUAGE_MAP: Record<string, readonly string[]> = {
   permutar: ['es'],
   permuter: ['fr'],
   peroleh: ['id'],
+  'perte de focus': ['fr'],
   phát: ['vi'],
   'phát-trực-tiếp': ['vi'],
   phawachiy: ['qu'],
@@ -1424,6 +1431,7 @@ export const KEYWORD_LANGUAGE_MAP: Record<string, readonly string[]> = {
   redefinir: ['pt'],
   redimensionamento: ['pt'],
   redimensionar: ['es', 'pt'],
+  redimensionnement: ['fr'],
   redimensionner: ['fr'],
   reemplazar: ['es'],
   registrar: ['es', 'pt'],
@@ -3502,7 +3510,7 @@ export const SCRIPT_RANGES: readonly {
 ];
 
 /**
- * Total keywords: 3300
+ * Total keywords: 3308
  * Total languages: 24
  * Ambiguous keywords (match 2+ languages): 195
  */


### PR DESCRIPTION
## Summary

Seven event-vocabulary corrections from loka-js's second research wave (tr and fr), each verified by an adversarial second-pass Deep Research review (2026-07-30) before landing. Same shape as #816: primary/alternative swaps only — **every demoted spelling remains a parse alternative**, so nothing that parsed before stops parsing, and the forms the i18n dict emits keep round-tripping as literals.

### Turkish

| Keyword | Was | Now | Why |
|---|---|---|---|
| `blur` | `bulanık` | `odak kaybı` (+ ASCII twin `odak kaybi`) | The fifth locale found shipping the *optical* blur sense (CSS filters, image processing) — "absolutely never used by native developers" for the DOM event; the pedagogical term is the loss-of-focus construction, same as de/pt/es/fr |
| `input` | `giriş` | `girdi` | `giriş` reads as entry/login (`giriş yapma`) and can imply an authentication event; `girdi` is the data-input term ("Girdi (Input) Eventleri") |
| `focus` | `odak` | `odaklanma` | Event noun (the act of acquiring focus, "odaklanma olayı") over the static state noun; both were already registered, pure reorder |
| `scroll` | `kaydır` | `kaydırma` (+ twin `kaydirma`) | Bare imperative → attested verbal noun ("kaydırma olayı"); the imperative stays as an alternative for the command sense |

### French

| Keyword | Was | Now | Why |
|---|---|---|---|
| `blur` | `défocaliser` | `perte de focus` | Same optical-sense defect class, sixth locale; `défocaliser` is an unattested infinitive |
| `scroll` | `défiler` | `défilement` (+ twin `defilement`) | MDN fr and the OQLF standardize the noun ("l'événement de défilement") |
| `resize` | `redimensionner` | `redimensionnement` | "lors du redimensionnement de la fenêtre" is the documented phrasing; the dict-emitted infinitive stays as an alternative so the event keeps typing as `literal="resize"` |

### Not included, deliberately

loka's `fr:focus` conclusion (publish *nothing* — "focus" is wholly assimilated French jargon and `focaliser` is the infinitive of a form the industry ignores) is **not** applied here: `focaliser` is load-bearing beyond the profile (French tokenizer, event-handler patterns, generated grammar), so removing it changes French hyperscript parsing and deserves its own decision in this repo. Tracked as the one remaining `pending-upstream` record on the loka side.

## Test plan

- [x] `npm run generate:grammar` — nearley grammar regenerated from the edited profiles; `check:grammar` clean
- [x] `check:mapper-parity` clean
- [x] Full semantic suite: **114 files, 7693 tests passing**
- [x] Downstream: loka-js regenerated its published locale data from this branch — drift, vocab-ordering (two-sided: new primary wins, old spellings still parse), and its 10-phase Playwright acceptance suite all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)