### PR TITLE
docs(changelog): roll the stale [Unreleased] block into 2.9.0, open 2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.0] - 2026-08-01
+
+Full notes: [GitHub Releases](https://github.com/codetalcott/hyperfixi/releases/tag/v2.10.0).
+
+Highlights: `swap`/`process`/`morph … using view transition` across all 24
+languages (#870, #873, #875), typed command registration (#869, #871),
+`tell`/`process` parser fixes (#861, #872), the R1 role-fidelity burn-down
+(#864, #867, #868, #874, #878), and guards for the remaining hand-maintained
+CI package lists (#862, #865).
+
+## [2.9.0] - 2026-07-25
+
+> **Gap note:** 2.9.1 through 2.9.4 shipped without entries in this file; their
+> details live in [GitHub Releases](https://github.com/codetalcott/hyperfixi/releases).
+
 ### ⚠ BREAKING (types)
 
 - **Domain renderers return `string | null`.** `renderSQL`, `renderJSX`, `renderTodo`,
@@ -379,7 +394,12 @@ _Synchronized version release. See git history for details._
 - npm access token stored in GitHub Secrets
 - 2FA recommended for npm organization
 
-[Unreleased]: https://github.com/codetalcott/hyperfixi/compare/v2.4.0...HEAD
+[Unreleased]: https://github.com/codetalcott/hyperfixi/compare/v2.10.0...HEAD
+[2.10.0]: https://github.com/codetalcott/hyperfixi/compare/v2.9.0...v2.10.0
+[2.9.0]: https://github.com/codetalcott/hyperfixi/compare/v2.8.0...v2.9.0
+[2.8.0]: https://github.com/codetalcott/hyperfixi/compare/v2.5.1...v2.8.0
+[2.5.1]: https://github.com/codetalcott/hyperfixi/compare/v2.5.0...v2.5.1
+[2.5.0]: https://github.com/codetalcott/hyperfixi/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/codetalcott/hyperfixi/compare/v2.3.1...v2.4.0
 [2.3.1]: https://github.com/codetalcott/hyperfixi/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/codetalcott/hyperfixi/compare/v2.2.1...v2.3.0


### PR DESCRIPTION
## Summary

Release bookkeeping ahead of v2.10.0.

The `## [Unreleased]` section **was** the 2.9.0 changelog — written in `50414e54` ("docs: extension API, renderer contract, and the 2.9.0 changelog") and never given a version heading. 2.9.1 through 2.9.4 then shipped with no entries at all, so the newest released heading in this file read **2.8.0**, five releases behind.

That matters at publish time specifically: `scripts/sync-changelogs.cjs` copies the root `CHANGELOG.md` into every publishable package (each lists it in `files`). A 2.10.0 release would therefore have shipped ~35 tarballs carrying a changelog that presents 2.9.0's **`renderX` returns `string | null`** breaking notice as *unreleased* — the one entry consumers are most likely to go looking for.

## What changed

- Heads the existing block as `## [2.9.0] - 2026-07-25`, with a gap note for 2.9.1–2.9.4 pointing at GitHub Releases. This is the same convention the 2.8.0 entry already uses for 2.6.0–2.7.2.
- Opens a `## [2.10.0] - 2026-08-01` stub pointing at the generated release notes, with a one-paragraph highlight list (view-transition tails #870/#873/#875, typed command registration #869/#871, `tell`/`process` parser fixes #861/#872, the R1 burn-down #864/#867/#868/#874/#878, CI list guards #862/#865).
- Repairs the compare links at the bottom: `[Unreleased]` still spanned from `v2.4.0`, and 2.5.0, 2.5.1 and 2.8.0 had no refs at all.

No code, no version bump — publish.yml does the bump itself from `version-type=minor`.

## Verification

Docs-only diff, so the `changes` path filter skips the npm stack; the skipped required checks satisfy branch protection as designed. A `publish.yml` dry run for 2.10.0 is running in parallel on `main` (run [30727416905](https://github.com/codetalcott/hyperfixi/actions/runs/30727416905)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)