### PR TITLE
feat(mcp-server): migrate to MCP TS SDK v2, protocol revision 2026-07-28

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -844,18 +844,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.14.1"
-      },
-      "peerDependencies": {
-        "hono": "^4"
-      }
-    },
     "node_modules/@hutson/parse-repository-url": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz",
@@ -1682,67 +1670,48 @@
       "resolved": "packages/semantic",
       "link": true
     },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
-        "cross-spawn": "^7.0.5",
-        "eventsource": "^3.0.2",
-        "eventsource-parser": "^3.0.0",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.2.1",
-        "hono": "^4.11.4",
-        "jose": "^6.1.3",
-        "json-schema-typed": "^8.0.2",
-        "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.1"
+        "zod": "^4.2.0"
       },
       "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
-          "optional": true
-        },
-        "zod": {
-          "optional": false
-        }
+        "node": ">=20"
       }
     },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+    "node_modules/@modelcontextprotocol/core/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
       },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
+      "engines": {
+        "node": ">=20"
       }
     },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
+    "node_modules/@modelcontextprotocol/server/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.4",
@@ -5237,45 +5206,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
     "node_modules/ansi-align": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
@@ -6734,23 +6664,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cors": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
-      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4",
-        "vary": "^1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/corser": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
@@ -6791,6 +6704,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -7680,27 +7594,6 @@
         "bare-events": "^2.7.0"
       }
     },
-    "node_modules/eventsource": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
-      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
-      "license": "MIT",
-      "dependencies": {
-        "eventsource-parser": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/eventsource-parser": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
-      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/exact-mirror": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/exact-mirror/-/exact-mirror-0.2.7.tgz",
@@ -7799,24 +7692,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/express-rate-limit": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
-      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^10.2.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": ">= 4.11"
-      }
-    },
     "node_modules/express/node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -7883,12 +7758,6 @@
       "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
       "license": "MIT"
     },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
-    },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
@@ -7922,22 +7791,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -9380,6 +9233,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -9451,15 +9305,6 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jose": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/joycon": {
@@ -9601,12 +9446,6 @@
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
-    },
-    "node_modules/json-schema-typed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/json-stringify-nice": {
       "version": "1.1.4",
@@ -11741,6 +11580,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12499,6 +12339,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12583,15 +12424,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/pkce-challenge": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
-      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -14107,6 +13939,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -14119,6 +13952,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -16193,6 +16027,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -16597,15 +16432,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zwitch": {
@@ -19274,7 +19100,7 @@
         "@lokascript/framework": "^2.10.0",
         "@lokascript/planner": "^2.10.0",
         "@lokascript/semantic": "^2.10.0",
-        "@modelcontextprotocol/sdk": "^1.25.0",
+        "@modelcontextprotocol/server": "^2.0.0",
         "yaml": "^2.8.3"
       },
       "bin": {

--- a/packages/framework/scripts/create-domain.ts
+++ b/packages/framework/scripts/create-domain.ts
@@ -509,7 +509,7 @@ function genMcpTools(args: Args): string {
   return `/**
  * MCP tools for domain-${args.name}
  */
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 
 // Lazy-loaded DSL instance
 let dslInstance: ReturnType<typeof import('@lokascript/domain-${args.name}').${dslFactory}> | null = null;

--- a/packages/framework/src/api/domain-registry.ts
+++ b/packages/framework/src/api/domain-registry.ts
@@ -117,7 +117,7 @@ export interface DomainDescriptor {
 }
 
 // =============================================================================
-// MCP Tool Types (minimal — compatible with @modelcontextprotocol/sdk)
+// MCP Tool Types (minimal — compatible with @modelcontextprotocol/server)
 // =============================================================================
 
 /**

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **MCP TypeScript SDK v2 / protocol revision 2026-07-28.** Migrated from
+  `@modelcontextprotocol/sdk` (v1) to `@modelcontextprotocol/server` `^2.0.0`.
+  The server now serves **both protocol eras** per connection via `serveStdio`:
+  the stateless `2026-07-28` revision (mandatory `server/discover`, no
+  `initialize` handshake, `resultType` stamped on every result) and the legacy
+  `initialize` dialect for current clients. Tool definitions remain plain JSON
+  Schema; the single `tools/call` dispatch path and the freshness guard are
+  unchanged.
+- **Cache hints (protocol 2026-07-28):** `tools/list`, `prompts/list`,
+  `resources/list`, and `resources/read` responses now advertise
+  `ttlMs: 3600000` / `cacheScope: "public"` — all four surfaces are static per
+  process.
+
+### Deprecated
+
+- The five sampling tools (`ask_claude`, `summarize_content`, `analyze_content`,
+  `translate_content`, `execute_llm`) rely on MCP sampling
+  (`sampling/createMessage`), which protocol revision 2026-07-28 deprecates —
+  server-initiated requests only exist on legacy-era connections whose client
+  advertises the sampling capability. They keep working there through the SDK's
+  ≥12-month deprecation window; on modern-era connections they return a clear
+  `isError` explanation. Deferred follow-up: convert them to the
+  `input_required` (MRTR) pattern before sampling's removal (~2027-07).
+  Also deferred, deliberately: per-tool `outputSchema`, tool titles/annotations,
+  and the `io.modelcontextprotocol/tasks` extension (no tool is long-running
+  enough to warrant task handles).
+
 ### Fixed
 
 - **Dispatch:** `execute_lse`, `validate_lse`, and `translate_lse` were advertised

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -2,6 +2,15 @@
 
 MCP (Model Context Protocol) server for hyperscript and multilingual DSL development. Provides **107 tools**, **9 resources**, and **9 prompts** spanning: GRAIL workflow orchestration, validation, compilation, analysis, patterns, LSP bridge, language profiles, code generation, route extraction, 9 domain DSLs, IR conversion, cross-domain dispatch, MCP sampling, AI-assisted debugging, template inventory, and the LSE round-trip pipeline.
 
+## Protocol Support
+
+Built on the MCP TypeScript SDK v2 (`@modelcontextprotocol/server`) and serves **both protocol eras** on every stdio connection:
+
+- **`2026-07-28` (stateless):** `server/discover` answered cold, `resultType` on every result, and cache hints (`ttlMs: 3600000`, `cacheScope: "public"`) on `tools/list`, `prompts/list`, `resources/list`, and `resources/read`.
+- **Legacy (`initialize` handshake):** current clients (Claude Code, Claude Desktop) connect this way; nothing changes for them.
+
+The five sampling tools (`ask_claude`, `summarize_content`, `analyze_content`, `translate_content`, `execute_llm`) depend on MCP sampling, which revision `2026-07-28` deprecates — they work on legacy-era connections whose client advertises the sampling capability and return a clear error elsewhere.
+
 ## Installation
 
 ### From Source

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -43,7 +43,7 @@
     "@lokascript/framework": "^2.10.0",
     "@lokascript/planner": "^2.10.0",
     "@lokascript/semantic": "^2.10.0",
-    "@modelcontextprotocol/sdk": "^1.25.0",
+    "@modelcontextprotocol/server": "^2.0.0",
     "yaml": "^2.8.3"
   },
   "peerDependencies": {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -7,8 +7,8 @@
  */
 
 import { createRequire } from 'node:module';
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { Server, type Tool } from '@modelcontextprotocol/server';
+import { serveStdio } from '@modelcontextprotocol/server/stdio';
 import {
   captureFreshnessBaseline,
   freshnessSummary,
@@ -16,14 +16,6 @@ import {
   staleSinceStartup,
   staleToolError,
 } from './freshness.js';
-import {
-  CallToolRequestSchema,
-  GetPromptRequestSchema,
-  ListPromptsRequestSchema,
-  ListResourcesRequestSchema,
-  ListToolsRequestSchema,
-  ReadResourceRequestSchema,
-} from '@modelcontextprotocol/sdk/types.js';
 
 // Tool implementations
 import { analysisTools, handleAnalysisTool } from './tools/analysis.js';
@@ -100,285 +92,310 @@ const { version: pkgVersion } = createRequire(import.meta.url)('../package.json'
   version: string;
 };
 
-const server = new Server(
-  {
-    name: '@hyperfixi/mcp-server',
-    version: pkgVersion,
-  },
-  {
-    capabilities: {
-      tools: {},
-      resources: {},
-      prompts: {},
+// All list/read surfaces are static per process (tool/prompt/resource lists are
+// compile-time literals; resources are static docs). One hour rather than
+// "forever": a rebuild + restart may change them, and the freshness guard
+// refuses calls in the window where a cached list could mislead.
+const STATIC_SURFACE_CACHE = { ttlMs: 3_600_000, cacheScope: 'public' as const };
+
+// serveStdio may invoke this factory more than once per connection (a
+// server/discover probe instance is built optimistically and discarded when the
+// client falls back to legacy initialize), so it must stay side-effect-free:
+// registry construction and the freshness baseline live at module scope /
+// main(), which also keeps them describing the process rather than a
+// connection.
+function buildServer(): Server {
+  const server = new Server(
+    {
+      name: '@hyperfixi/mcp-server',
+      version: pkgVersion,
     },
-  }
-);
+    {
+      capabilities: {
+        tools: {},
+        resources: {},
+        prompts: {},
+      },
+      cacheHints: {
+        'tools/list': STATIC_SURFACE_CACHE,
+        'prompts/list': STATIC_SURFACE_CACHE,
+        'resources/list': STATIC_SURFACE_CACHE,
+        'resources/read': STATIC_SURFACE_CACHE,
+      },
+    }
+  );
 
-// =============================================================================
-// Tool Handlers
-// =============================================================================
+  // =============================================================================
+  // Tool Handlers
+  // =============================================================================
 
-server.setRequestHandler(ListToolsRequestSchema, async () => {
-  return {
-    tools: [
-      ...analysisTools,
-      ...patternTools,
-      ...validationTools,
-      ...lspBridgeTools,
-      ...languageDocsTools,
-      ...profileTools,
-      ...compilationTools,
-      ...routeTools,
-      ...registry.getToolDefinitions(),
-      ...samplingTools,
-      ...dispatcherTools,
-      ...irTools,
-      ...debugTools,
-      ...inventoryTools,
-      ...trainingDataTools,
-      ...feedbackTools,
-      ...lsePipelineTools,
-      ...grailTools,
-      ...lseCorrectionTools,
-    ],
-  };
-});
+  server.setRequestHandler('tools/list', async () => {
+    return {
+      tools: [
+        ...analysisTools,
+        ...patternTools,
+        ...validationTools,
+        ...lspBridgeTools,
+        ...languageDocsTools,
+        ...profileTools,
+        ...compilationTools,
+        ...routeTools,
+        // Cast: the framework's MCPToolDefinition types inputSchema.properties
+        // as Record<string, unknown>, wider than the SDK's JSONValue index —
+        // the values are plain JSON Schema literals at runtime.
+        ...(registry.getToolDefinitions() as unknown as Tool[]),
+        ...samplingTools,
+        ...dispatcherTools,
+        ...irTools,
+        ...debugTools,
+        ...inventoryTools,
+        ...trainingDataTools,
+        ...feedbackTools,
+        ...lsePipelineTools,
+        ...grailTools,
+        ...lseCorrectionTools,
+      ],
+    };
+  });
 
-server.setRequestHandler(CallToolRequestSchema, async request => {
-  const { name, arguments: args } = request.params;
+  server.setRequestHandler('tools/call', async request => {
+    const { name, arguments: args } = request.params;
 
-  // Freshness guard. This process resolved its workspace deps' dist/ at startup and Node
-  // cannot un-cache them, so a rebuild leaves every answer below reflecting the PRE-rebuild
-  // code — silently, which is this server's worst failure mode. Refuse instead, at the one
-  // choke point every tool call passes through. See ./freshness.ts for why detect-and-refuse
-  // rather than reload or bundle.
-  const stale = staleSinceStartup();
-  if (stale.length > 0) {
-    return staleToolError(stale);
-  }
-
-  // Analysis tools (from core/ast-utils)
-  if (name.startsWith('analyze_') || name === 'explain_code' || name === 'recognize_intent') {
-    return handleAnalysisTool(name, args as Record<string, unknown>);
-  }
-
-  // Pattern tools (from patterns-reference)
-  if (
-    name === 'search_patterns' ||
-    name === 'translate_hyperscript' ||
-    name === 'get_pattern_stats'
-  ) {
-    return handlePatternTool(name, args as Record<string, unknown>);
-  }
-
-  // Validation tools
-  if (
-    name === 'validate_hyperscript' ||
-    name === 'validate_schema' ||
-    name === 'suggest_command' ||
-    name === 'get_bundle_config' ||
-    name === 'parse_multilingual' ||
-    name === 'translate_to_english' ||
-    name === 'explain_in_language' ||
-    name === 'get_code_fixes'
-  ) {
-    return handleValidationTool(name, args as Record<string, unknown>);
-  }
-
-  // LSP Bridge tools
-  if (
-    name === 'get_diagnostics' ||
-    name === 'get_completions' ||
-    name === 'get_hover_info' ||
-    name === 'get_document_symbols'
-  ) {
-    return handleLspBridgeTool(name, args as Record<string, unknown>);
-  }
-
-  // Language documentation tools
-  if (
-    name === 'get_command_docs' ||
-    name === 'get_expression_docs' ||
-    name === 'search_language_elements' ||
-    name === 'suggest_best_practices'
-  ) {
-    return handleLanguageDocsTool(name, args as Record<string, unknown>);
-  }
-
-  // Profile inspection tools
-  if (
-    name === 'get_language_profile' ||
-    name === 'list_supported_languages' ||
-    name === 'get_keyword_translations' ||
-    name === 'get_role_markers' ||
-    name === 'compare_language_profiles'
-  ) {
-    return handleProfileTool(name, args as Record<string, unknown>);
-  }
-
-  // Compilation service tools
-  if (
-    name === 'compile_hyperscript' ||
-    name === 'validate_and_compile' ||
-    name === 'translate_code' ||
-    name === 'generate_tests' ||
-    name === 'generate_component' ||
-    name === 'diff_behaviors'
-  ) {
-    return handleCompilationTool(name, args as Record<string, unknown>);
-  }
-
-  // Cross-domain dispatcher tools
-  if (
-    name === 'detect_domain' ||
-    name === 'parse_composite' ||
-    name === 'compile_auto' ||
-    name === 'compile_composite'
-  ) {
-    return handleDispatcherTool(name, args as Record<string, unknown>, registry);
-  }
-
-  // IR conversion tools (explicit ↔ JSON, protocol validation, envelopes)
-  if (
-    name === 'convert_format' ||
-    name === 'validate_explicit' ||
-    name === 'validate_protocol' ||
-    name === 'to_envelope' ||
-    name === 'from_envelope'
-  ) {
-    return handleIRTool(name, args as Record<string, unknown>);
-  }
-
-  // Domain tools — registry handles standard operations,
-  // extras handle multi-step/multi-line extensions
-  if (registry.canHandle(name)) {
-    const typedArgs = args as Record<string, unknown>;
-
-    // Multi-step BDD scenarios (comma/newline-separated)
-    if (name.endsWith('_bdd') && isMultiStepBDD(typedArgs)) {
-      return handleBDDMultiStep(name, typedArgs) as any;
+    // Freshness guard. This process resolved its workspace deps' dist/ at startup and Node
+    // cannot un-cache them, so a rebuild leaves every answer below reflecting the PRE-rebuild
+    // code — silently, which is this server's worst failure mode. Refuse instead, at the one
+    // choke point every tool call passes through. See ./freshness.ts for why detect-and-refuse
+    // rather than reload or bundle.
+    const stale = staleSinceStartup();
+    if (stale.length > 0) {
+      return staleToolError(stale);
     }
 
-    // Multi-line BehaviorSpec scenarios (indented test blocks)
-    if (name.endsWith('_behaviorspec') && isMultiLineBehaviorSpec(typedArgs)) {
-      return handleBehaviorSpecMultiLine(name, typedArgs) as any;
+    // Analysis tools (from core/ast-utils)
+    if (name.startsWith('analyze_') || name === 'explain_code' || name === 'recognize_intent') {
+      return handleAnalysisTool(name, args as Record<string, unknown>);
     }
 
-    // Standard single-step: registry handles parse/compile/validate/translate
-    // Cast needed: MCPToolResponse uses readonly props vs SDK's mutable types
-    const result = await registry.handleToolCall(name, typedArgs);
-    if (result) return result as any;
-  }
+    // Pattern tools (from patterns-reference)
+    if (
+      name === 'search_patterns' ||
+      name === 'translate_hyperscript' ||
+      name === 'get_pattern_stats'
+    ) {
+      return handlePatternTool(name, args as Record<string, unknown>);
+    }
 
-  // ServerBridge route tools
-  if (name === 'extract_routes' || name === 'generate_server_routes') {
-    return handleRouteTool(name, args as Record<string, unknown>);
-  }
+    // Validation tools
+    if (
+      name === 'validate_hyperscript' ||
+      name === 'validate_schema' ||
+      name === 'suggest_command' ||
+      name === 'get_bundle_config' ||
+      name === 'parse_multilingual' ||
+      name === 'translate_to_english' ||
+      name === 'explain_in_language' ||
+      name === 'get_code_fixes'
+    ) {
+      return handleValidationTool(name, args as Record<string, unknown>);
+    }
 
-  // MCP Sampling tools (Layer 3 — invoke Claude via client)
-  if (
-    name === 'ask_claude' ||
-    name === 'summarize_content' ||
-    name === 'analyze_content' ||
-    name === 'translate_content' ||
-    name === 'execute_llm'
-  ) {
-    return handleSamplingTool(name, args as Record<string, unknown>, server, registry);
-  }
+    // LSP Bridge tools
+    if (
+      name === 'get_diagnostics' ||
+      name === 'get_completions' ||
+      name === 'get_hover_info' ||
+      name === 'get_document_symbols'
+    ) {
+      return handleLspBridgeTool(name, args as Record<string, unknown>);
+    }
 
-  // Debug tools (AI-assisted debugging)
-  if (name.startsWith('debug_')) {
-    return handleDebugTool(name, args as Record<string, unknown>);
-  }
+    // Language documentation tools
+    if (
+      name === 'get_command_docs' ||
+      name === 'get_expression_docs' ||
+      name === 'search_language_elements' ||
+      name === 'suggest_best_practices'
+    ) {
+      return handleLanguageDocsTool(name, args as Record<string, unknown>);
+    }
 
-  // Template inventory tools
-  if (name === 'scan_inventory' || name === 'query_inventory') {
-    return handleInventoryTool(name, args as Record<string, unknown>);
-  }
+    // Profile inspection tools
+    if (
+      name === 'get_language_profile' ||
+      name === 'list_supported_languages' ||
+      name === 'get_keyword_translations' ||
+      name === 'get_role_markers' ||
+      name === 'compare_language_profiles'
+    ) {
+      return handleProfileTool(name, args as Record<string, unknown>);
+    }
 
-  // Training data tools (LLM ↔ LSE)
-  if (name === 'generate_training_data') {
-    return handleTrainingDataTool(name, args as Record<string, unknown>);
-  }
+    // Compilation service tools
+    if (
+      name === 'compile_hyperscript' ||
+      name === 'validate_and_compile' ||
+      name === 'translate_code' ||
+      name === 'generate_tests' ||
+      name === 'generate_component' ||
+      name === 'diff_behaviors'
+    ) {
+      return handleCompilationTool(name, args as Record<string, unknown>);
+    }
 
-  // Feedback loop tools (LLM ↔ LSE)
-  if (name === 'lse_validate_and_feedback' || name === 'lse_pattern_stats') {
-    return handleFeedbackTool(name, args as Record<string, unknown>);
-  }
+    // Cross-domain dispatcher tools
+    if (
+      name === 'detect_domain' ||
+      name === 'parse_composite' ||
+      name === 'compile_auto' ||
+      name === 'compile_composite'
+    ) {
+      return handleDispatcherTool(name, args as Record<string, unknown>, registry);
+    }
 
-  // LSE pipeline tools (LLM round-trip: hyperscript ↔ LSE, plus the LSE 2.0
-  // LLM-native tools — all five are defined in lsePipelineTools and handled by
-  // handleLsePipelineTool; the last three were advertised but unrouted here.)
-  if (
-    name === 'lse_from_hyperscript' ||
-    name === 'lse_to_hyperscript' ||
-    name === 'execute_lse' ||
-    name === 'validate_lse' ||
-    name === 'translate_lse'
-  ) {
-    return handleLsePipelineTool(name, args as Record<string, unknown>);
-  }
+    // IR conversion tools (explicit ↔ JSON, protocol validation, envelopes)
+    if (
+      name === 'convert_format' ||
+      name === 'validate_explicit' ||
+      name === 'validate_protocol' ||
+      name === 'to_envelope' ||
+      name === 'from_envelope'
+    ) {
+      return handleIRTool(name, args as Record<string, unknown>);
+    }
 
-  // GRAIL tools (condition/affordance workflow)
-  if (name.startsWith('grail_')) {
-    return handleGrailTool(name, args as Record<string, unknown>);
-  }
+    // Domain tools — registry handles standard operations,
+    // extras handle multi-step/multi-line extensions
+    if (registry.canHandle(name)) {
+      const typedArgs = args as Record<string, unknown>;
 
-  // LSE correction tool (stateless generation + self-correction loop)
-  if (name === 'lse_generate_with_correction') {
-    return handleLseCorrectionTool(name, args as Record<string, unknown>);
-  }
+      // Multi-step BDD scenarios (comma/newline-separated)
+      if (name.endsWith('_bdd') && isMultiStepBDD(typedArgs)) {
+        return handleBDDMultiStep(name, typedArgs) as any;
+      }
 
-  // Pattern tools with get_ prefix (after LSP, language-docs, and profile tools to avoid conflict)
-  if (name.startsWith('get_')) {
-    return handlePatternTool(name, args as Record<string, unknown>);
-  }
+      // Multi-line BehaviorSpec scenarios (indented test blocks)
+      if (name.endsWith('_behaviorspec') && isMultiLineBehaviorSpec(typedArgs)) {
+        return handleBehaviorSpecMultiLine(name, typedArgs) as any;
+      }
 
-  return {
-    content: [{ type: 'text', text: `Unknown tool: ${name}` }],
-    isError: true,
-  };
-});
+      // Standard single-step: registry handles parse/compile/validate/translate
+      // Cast needed: MCPToolResponse uses readonly props vs SDK's mutable types
+      const result = await registry.handleToolCall(name, typedArgs);
+      if (result) return result as any;
+    }
 
-// =============================================================================
-// Prompt Handlers (Layer 2)
-// =============================================================================
+    // ServerBridge route tools
+    if (name === 'extract_routes' || name === 'generate_server_routes') {
+      return handleRouteTool(name, args as Record<string, unknown>);
+    }
 
-server.setRequestHandler(ListPromptsRequestSchema, async () => {
-  return {
-    prompts: [
-      ...getLLMPromptDefinitions(),
-      ...getDebugPromptDefinitions(),
-      ...getLSEPromptDefinitions(),
-    ],
-  };
-});
+    // MCP Sampling tools (Layer 3 — invoke Claude via client)
+    if (
+      name === 'ask_claude' ||
+      name === 'summarize_content' ||
+      name === 'analyze_content' ||
+      name === 'translate_content' ||
+      name === 'execute_llm'
+    ) {
+      return handleSamplingTool(name, args as Record<string, unknown>, server, registry);
+    }
 
-server.setRequestHandler(GetPromptRequestSchema, async request => {
-  const { name, arguments: promptArgs } = request.params;
-  const typedArgs = (promptArgs ?? {}) as Record<string, string>;
+    // Debug tools (AI-assisted debugging)
+    if (name.startsWith('debug_')) {
+      return handleDebugTool(name, args as Record<string, unknown>);
+    }
 
-  if (isDebugPrompt(name)) {
-    return renderDebugPrompt(name, typedArgs);
-  }
-  if (isLSEPrompt(name)) {
-    return renderLSEPrompt(name, typedArgs);
-  }
-  return renderLLMPrompt(name, typedArgs);
-});
+    // Template inventory tools
+    if (name === 'scan_inventory' || name === 'query_inventory') {
+      return handleInventoryTool(name, args as Record<string, unknown>);
+    }
 
-// =============================================================================
-// Resource Handlers
-// =============================================================================
+    // Training data tools (LLM ↔ LSE)
+    if (name === 'generate_training_data') {
+      return handleTrainingDataTool(name, args as Record<string, unknown>);
+    }
 
-server.setRequestHandler(ListResourcesRequestSchema, async () => {
-  return { resources: listResources() };
-});
+    // Feedback loop tools (LLM ↔ LSE)
+    if (name === 'lse_validate_and_feedback' || name === 'lse_pattern_stats') {
+      return handleFeedbackTool(name, args as Record<string, unknown>);
+    }
 
-server.setRequestHandler(ReadResourceRequestSchema, async request => {
-  const { uri } = request.params;
-  return readResource(uri);
-});
+    // LSE pipeline tools (LLM round-trip: hyperscript ↔ LSE, plus the LSE 2.0
+    // LLM-native tools — all five are defined in lsePipelineTools and handled by
+    // handleLsePipelineTool; the last three were advertised but unrouted here.)
+    if (
+      name === 'lse_from_hyperscript' ||
+      name === 'lse_to_hyperscript' ||
+      name === 'execute_lse' ||
+      name === 'validate_lse' ||
+      name === 'translate_lse'
+    ) {
+      return handleLsePipelineTool(name, args as Record<string, unknown>);
+    }
+
+    // GRAIL tools (condition/affordance workflow)
+    if (name.startsWith('grail_')) {
+      return handleGrailTool(name, args as Record<string, unknown>);
+    }
+
+    // LSE correction tool (stateless generation + self-correction loop)
+    if (name === 'lse_generate_with_correction') {
+      return handleLseCorrectionTool(name, args as Record<string, unknown>);
+    }
+
+    // Pattern tools with get_ prefix (after LSP, language-docs, and profile tools to avoid conflict)
+    if (name.startsWith('get_')) {
+      return handlePatternTool(name, args as Record<string, unknown>);
+    }
+
+    return {
+      content: [{ type: 'text', text: `Unknown tool: ${name}` }],
+      isError: true,
+    };
+  });
+
+  // =============================================================================
+  // Prompt Handlers (Layer 2)
+  // =============================================================================
+
+  server.setRequestHandler('prompts/list', async () => {
+    return {
+      prompts: [
+        ...getLLMPromptDefinitions(),
+        ...getDebugPromptDefinitions(),
+        ...getLSEPromptDefinitions(),
+      ],
+    };
+  });
+
+  server.setRequestHandler('prompts/get', async request => {
+    const { name, arguments: promptArgs } = request.params;
+    const typedArgs = (promptArgs ?? {}) as Record<string, string>;
+
+    if (isDebugPrompt(name)) {
+      return renderDebugPrompt(name, typedArgs);
+    }
+    if (isLSEPrompt(name)) {
+      return renderLSEPrompt(name, typedArgs);
+    }
+    return renderLLMPrompt(name, typedArgs);
+  });
+
+  // =============================================================================
+  // Resource Handlers
+  // =============================================================================
+
+  server.setRequestHandler('resources/list', async () => {
+    return { resources: listResources() };
+  });
+
+  server.setRequestHandler('resources/read', async request => {
+    const { uri } = request.params;
+    return readResource(uri);
+  });
+
+  return server;
+}
 
 // =============================================================================
 // Server Startup
@@ -404,8 +421,12 @@ async function main() {
     );
   }
 
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
+  // serveStdio serves both protocol eras per connection: the stateless
+  // 2026-07-28 revision (server/discover, no handshake) and the legacy
+  // initialize dialect — legacy stays at its default 'serve' because current
+  // clients (including Claude Code) still connect via initialize, and the
+  // sampling tools only work on that era.
+  serveStdio(() => buildServer());
   console.error(`HyperFixi MCP server started (${freshnessSummary()})`);
 }
 

--- a/packages/mcp-server/src/prompts/debug-prompts.ts
+++ b/packages/mcp-server/src/prompts/debug-prompts.ts
@@ -6,7 +6,7 @@
  * suggest appropriate breakpoint placements.
  */
 
-import type { Prompt, GetPromptResult } from '@modelcontextprotocol/sdk/types.js';
+import type { Prompt, GetPromptResult } from '@modelcontextprotocol/server';
 
 // =============================================================================
 // Prompt Definitions

--- a/packages/mcp-server/src/prompts/index.ts
+++ b/packages/mcp-server/src/prompts/index.ts
@@ -6,7 +6,7 @@
  * protocol, making them available as slash-command-style prompts in Claude Code.
  */
 
-import type { Prompt, GetPromptResult } from '@modelcontextprotocol/sdk/types.js';
+import type { Prompt, GetPromptResult } from '@modelcontextprotocol/server';
 
 // =============================================================================
 // Prompt Definitions

--- a/packages/mcp-server/src/prompts/lse-prompts.ts
+++ b/packages/mcp-server/src/prompts/lse-prompts.ts
@@ -6,7 +6,7 @@
  * - lse_fix: Fix invalid LSE given diagnostics
  */
 
-import type { Prompt, GetPromptResult } from '@modelcontextprotocol/sdk/types.js';
+import type { Prompt, GetPromptResult } from '@modelcontextprotocol/server';
 
 // =============================================================================
 // Prompt Definitions

--- a/packages/mcp-server/src/resources/index.ts
+++ b/packages/mcp-server/src/resources/index.ts
@@ -4,7 +4,7 @@
  * Static documentation and example resources available to MCP clients.
  */
 
-import type { Resource } from '@modelcontextprotocol/sdk/types.js';
+import type { Resource } from '@modelcontextprotocol/server';
 import {
   getCommandsReference,
   getExpressionsGuide,

--- a/packages/mcp-server/src/tools/analysis.ts
+++ b/packages/mcp-server/src/tools/analysis.ts
@@ -5,7 +5,7 @@
  * These tools help LLMs understand hyperscript code structure and quality.
  */
 
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 
 // =============================================================================
 // Tool Definitions

--- a/packages/mcp-server/src/tools/compilation.ts
+++ b/packages/mcp-server/src/tools/compilation.ts
@@ -5,7 +5,7 @@
  * Compile, validate, translate, generate tests, and generate components.
  */
 
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 
 // Lazy-import compilation service (resolved at first call)
 let servicePromise: Promise<any> | null = null;

--- a/packages/mcp-server/src/tools/debug-tools.ts
+++ b/packages/mcp-server/src/tools/debug-tools.ts
@@ -6,7 +6,7 @@
  * suggest fixes, and trace variable changes.
  */
 
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 
 // =============================================================================
 // Tool Definitions

--- a/packages/mcp-server/src/tools/dispatcher.ts
+++ b/packages/mcp-server/src/tools/dispatcher.ts
@@ -6,6 +6,7 @@
  * and compile-without-specifying-domain.
  */
 
+import type { Tool } from '@modelcontextprotocol/server';
 import { CrossDomainDispatcher, type DomainRegistry } from '@lokascript/framework';
 import { DOMAIN_PRIORITY } from '@lokascript/domain-config';
 import { getString, getNumber, jsonResponse, errorResponse } from './utils.js';
@@ -41,7 +42,7 @@ function serializeRoles(roles: ReadonlyMap<string, unknown>): Record<string, unk
 // Tool Definitions
 // =============================================================================
 
-export const dispatcherTools = [
+export const dispatcherTools: Tool[] = [
   {
     name: 'detect_domain',
     description:

--- a/packages/mcp-server/src/tools/feedback-tools.ts
+++ b/packages/mcp-server/src/tools/feedback-tools.ts
@@ -5,7 +5,7 @@
  * Provides LSE validation with structured feedback and pattern statistics.
  */
 
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 import type { SchemaLookup, Diagnostic, CommandSchema } from '@lokascript/framework';
 
 export const feedbackTools: Tool[] = [

--- a/packages/mcp-server/src/tools/grail-tools.ts
+++ b/packages/mcp-server/src/tools/grail-tools.ts
@@ -7,7 +7,7 @@
  * Wire-compatible with grail-domains (GRAIL spec §7).
  */
 
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 import { jsonResponse, errorResponse, getString, getBoolean } from './utils.js';
 import { loadGrailConfig, findGrailYaml } from './grail-yaml-loader.js';
 import { GrailRegistry } from './grail-registry.js';

--- a/packages/mcp-server/src/tools/inventory.ts
+++ b/packages/mcp-server/src/tools/inventory.ts
@@ -5,7 +5,7 @@
  * hyperscript/htmx usage across HTML templates.
  */
 
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 import { jsonResponse, errorResponse, getString, getNumber } from './utils.js';
 
 type ToolResponse = { content: Array<{ type: string; text: string }>; isError?: boolean };

--- a/packages/mcp-server/src/tools/ir-tools.ts
+++ b/packages/mcp-server/src/tools/ir-tools.ts
@@ -5,7 +5,7 @@
  * protocol JSON without full compilation. Uses @lokascript/framework/ir directly.
  */
 
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 import type { SemanticNode } from '@lokascript/framework';
 import {
   parseExplicit,

--- a/packages/mcp-server/src/tools/language-docs.ts
+++ b/packages/mcp-server/src/tools/language-docs.ts
@@ -11,7 +11,7 @@
  * - Features/Symbols: static catalogs
  */
 
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 
 // =============================================================================
 // Semantic Package Import (module-level, following validation.ts pattern)
@@ -793,7 +793,7 @@ const ROLE_CATALOG: Record<
     description: 'Who receives what the action transfers — the far end of a transfer.',
     origin: 'Linguistic thematic role: the beneficiary/goal of a transfer.',
     usage:
-      "The element a class moves ONTO in `take` (its patient moves OFF the source), so both ends are named. Marked with `for` in English; most languages render it as a bare trailing pronoun.",
+      'The element a class moves ONTO in `take` (its patient moves OFF the source), so both ends are named. Marked with `for` in English; most languages render it as a bare trailing pronoun.',
     commands: ['take'],
     explicitExample: '[take patient:.active source:.tab-button recipient:me]',
   },

--- a/packages/mcp-server/src/tools/llm-sampling.ts
+++ b/packages/mcp-server/src/tools/llm-sampling.ts
@@ -12,8 +12,8 @@
  *   Natural language (8 languages) → domain-llm.compile() → LLMPromptSpec → sampling
  */
 
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
-import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import type { Tool } from '@modelcontextprotocol/server';
+import type { Server } from '@modelcontextprotocol/server';
 import type { DomainRegistry } from '@lokascript/framework';
 import type { LLMPromptSpec, LLMMessage } from '@lokascript/domain-llm';
 
@@ -25,7 +25,7 @@ export const samplingTools: Tool[] = [
   {
     name: 'ask_claude',
     description:
-      'Ask Claude a question with optional context. Uses MCP sampling — the client handles model selection and user approval.',
+      'Ask Claude a question with optional context. Uses MCP sampling — the client handles model selection and user approval. DEPRECATED: MCP sampling is deprecated as of protocol revision 2026-07-28 and works only on legacy-era connections whose client advertises the sampling capability; planned replacement is the input_required (MRTR) pattern.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -53,7 +53,7 @@ export const samplingTools: Tool[] = [
   {
     name: 'summarize_content',
     description:
-      'Summarize text content using Claude. Uses MCP sampling — the client handles model selection and user approval.',
+      'Summarize text content using Claude. Uses MCP sampling — the client handles model selection and user approval. DEPRECATED: MCP sampling is deprecated as of protocol revision 2026-07-28 and works only on legacy-era connections whose client advertises the sampling capability; planned replacement is the input_required (MRTR) pattern.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -81,7 +81,7 @@ export const samplingTools: Tool[] = [
   {
     name: 'analyze_content',
     description:
-      'Analyze text content for sentiment, entities, themes, or other qualities using Claude. Uses MCP sampling.',
+      'Analyze text content for sentiment, entities, themes, or other qualities using Claude. Uses MCP sampling. DEPRECATED: MCP sampling is deprecated as of protocol revision 2026-07-28 and works only on legacy-era connections whose client advertises the sampling capability; planned replacement is the input_required (MRTR) pattern.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -105,7 +105,7 @@ export const samplingTools: Tool[] = [
   {
     name: 'translate_content',
     description:
-      'Translate text between natural languages using Claude. Uses MCP sampling — the client handles model selection and user approval.',
+      'Translate text between natural languages using Claude. Uses MCP sampling — the client handles model selection and user approval. DEPRECATED: MCP sampling is deprecated as of protocol revision 2026-07-28 and works only on legacy-era connections whose client advertises the sampling capability; planned replacement is the input_required (MRTR) pattern.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -132,7 +132,7 @@ export const samplingTools: Tool[] = [
   {
     name: 'execute_llm',
     description:
-      'Execute an LLM command written in natural language (8 languages supported). Compiles via domain-llm then invokes Claude via MCP sampling. Examples: "ask what is 2+2", "summarize #article as bullets", "요약 이 문서를 글머리로" (Korean).',
+      'Execute an LLM command written in natural language (8 languages supported). Compiles via domain-llm then invokes Claude via MCP sampling. Examples: "ask what is 2+2", "summarize #article as bullets", "요약 이 문서를 글머리로" (Korean). DEPRECATED: MCP sampling is deprecated as of protocol revision 2026-07-28 and works only on legacy-era connections whose client advertises the sampling capability; planned replacement is the input_required (MRTR) pattern.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -340,12 +340,36 @@ export async function handleSamplingTool(
  */
 async function executeSpec(spec: LLMPromptSpec, server: Server): Promise<ToolResponse> {
   const params = specToSamplingParams(spec);
-  const response = await server.createMessage(params);
+  // createMessage is a server→client push, which the stateless 2026-07-28
+  // protocol removed — it only works on legacy-era connections whose client
+  // advertises the sampling capability. Explain that instead of surfacing a
+  // bare protocol error.
+  let response: Awaited<ReturnType<Server['createMessage']>>;
+  try {
+    response = await server.createMessage(params);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      content: [
+        {
+          type: 'text',
+          text:
+            `Sampling unavailable: ${message}. This tool relies on MCP sampling ` +
+            `(deprecated in protocol revision 2026-07-28), which requires a ` +
+            `legacy-era connection and a client that advertises the sampling capability.`,
+        },
+      ],
+      isError: true,
+    };
+  }
 
+  // SDK v2 models CreateMessageResult.content as a single block OR an array of
+  // blocks; these tools expect a single text answer, so read the first block.
+  const block = Array.isArray(response.content) ? response.content[0] : response.content;
   const text =
-    response.content.type === 'text'
-      ? response.content.text
-      : `Received non-text response of type: ${response.content.type}`;
+    block?.type === 'text'
+      ? block.text
+      : `Received non-text response of type: ${block?.type ?? 'empty'}`;
 
   return { content: [{ type: 'text', text }] };
 }

--- a/packages/mcp-server/src/tools/lse-correction.ts
+++ b/packages/mcp-server/src/tools/lse-correction.ts
@@ -23,7 +23,7 @@
  *   5. Repeat up to maxRounds (default 3)
  */
 
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 import { jsonResponse, errorResponse } from './utils.js';
 
 // =============================================================================

--- a/packages/mcp-server/src/tools/lse-pipeline.ts
+++ b/packages/mcp-server/src/tools/lse-pipeline.ts
@@ -9,7 +9,7 @@
  *   - lse_to_hyperscript: validate/compile LSE from an LLM response → JS
  */
 
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 import { jsonResponse, errorResponse } from './utils.js';
 
 // =============================================================================

--- a/packages/mcp-server/src/tools/lsp-bridge.ts
+++ b/packages/mcp-server/src/tools/lsp-bridge.ts
@@ -5,7 +5,7 @@
  * Supports 21 languages via @lokascript/semantic for multilingual assistance.
  */
 
-import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import type { CallToolResult, Tool } from '@modelcontextprotocol/server';
 
 // Try to import ast-utils from core
 let astToolkit: any = null;
@@ -115,7 +115,7 @@ function getSemanticAnalyzer(): typeof cachedAnalyzer {
 // LSP Bridge Tool Definitions
 // ============================================================================
 
-export const lspBridgeTools = [
+export const lspBridgeTools: Tool[] = [
   {
     name: 'get_diagnostics',
     description:

--- a/packages/mcp-server/src/tools/patterns.ts
+++ b/packages/mcp-server/src/tools/patterns.ts
@@ -5,7 +5,7 @@
  * These tools help LLMs generate correct hyperscript by providing examples.
  */
 
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 
 // =============================================================================
 // Tool Definitions

--- a/packages/mcp-server/src/tools/profiles.ts
+++ b/packages/mcp-server/src/tools/profiles.ts
@@ -5,7 +5,7 @@
  * references, and other language-specific configuration.
  */
 
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 import {
   tryGetProfile,
   getRegisteredLanguages,

--- a/packages/mcp-server/src/tools/routes.ts
+++ b/packages/mcp-server/src/tools/routes.ts
@@ -6,6 +6,7 @@
  * for Express, Hono, OpenAPI, Django, and FastAPI targets.
  */
 
+import type { Tool } from '@modelcontextprotocol/server';
 import { validateRequired, getString, getBoolean, jsonResponse, errorResponse } from './utils.js';
 
 // Lazy-loaded ServerBridge modules
@@ -37,7 +38,7 @@ async function getScanRoutes() {
 // Tool Definitions
 // =============================================================================
 
-export const routeTools = [
+export const routeTools: Tool[] = [
   {
     name: 'extract_routes',
     description:

--- a/packages/mcp-server/src/tools/training-data.ts
+++ b/packages/mcp-server/src/tools/training-data.ts
@@ -5,7 +5,7 @@
  * Generates (natural_language, LSE) pairs from domain schemas.
  */
 
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 
 export const trainingDataTools: Tool[] = [
   {

--- a/packages/mcp-server/src/tools/validation.ts
+++ b/packages/mcp-server/src/tools/validation.ts
@@ -5,7 +5,7 @@
  * Supports 21 languages via @lokascript/semantic for multilingual validation.
  */
 
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 
 // Import error fixes registry
 import {


### PR DESCRIPTION
## Summary

Migrates `@hyperfixi/mcp-server` from the MCP TypeScript SDK v1 (`@modelcontextprotocol/sdk ^1.25.0`) to the v2 scoped package (`@modelcontextprotocol/server ^2.0.0`), targeting protocol revision **2026-07-28** while continuing to serve legacy clients. `serveStdio` owns the era decision per connection:

- **Stateless `2026-07-28` era:** `server/discover` answered cold (supportedVersions / capabilities / serverInfo), `resultType: "complete"` stamped on every result, and cache hints (`ttlMs: 3600000`, `cacheScope: "public"`) on `tools/list`, `prompts/list`, `resources/list`, `resources/read` — all static per process.
- **Legacy `initialize` era:** unchanged for current clients (Claude Code, Claude Desktop). The five sampling tools keep working there and are now marked deprecated (sampling is deprecated in 2026-07-28); a modern-era or no-capability `createMessage` failure returns a clear `isError` explanation instead of a bare protocol error.

Server wiring became a side-effect-free `buildServer()` factory (the discover probe instance can be built and discarded per connection) with method-string handlers. The 107-tool surface, the single `tools/call` dispatch chain, and the freshness-guard choke point are unchanged. Tool definitions stay plain JSON Schema; v2's stricter types surfaced three tool arrays (`lsp-bridge`, `routes`, `dispatcher`) that were never declared `Tool[]`, now annotated. The framework's `create-domain` generator emits the v2 import.

Deferred deliberately (documented in CHANGELOG): MRTR `input_required` conversion of the sampling tools, per-tool `outputSchema`, tool annotations/titles, and the `io.modelcontextprotocol/tasks` extension.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Dependencies update
- [ ] Bug fix / Breaking change / Documentation update / Refactoring / CI-Build changes

## Affected Packages

- [x] `@lokascript/mcp-server` (published as `@hyperfixi/mcp-server`)
- [x] Other: `@lokascript/framework` (create-domain generator template import; one comment)

## Test Plan

- [x] `npm run typecheck --prefix packages/mcp-server` — clean
- [x] `npm test --prefix packages/mcp-server` — 17 files, 428 tests pass **unmodified**
- [x] Stdio smoke, modern era: `server/discover` cold → `supportedVersions: ["2026-07-28"]`; `tools/list` → 107 tools with `resultType`/`ttlMs`/`cacheScope`; `tools/call validate_hyperscript` → executes with `resultType: "complete"`
- [x] Stdio smoke, legacy era: `initialize` handshake negotiates; `tools/list` 107 / `resources/list` 9 / `prompts/list` 9 (no 2026-era fields leak onto the 2025-era wire); live `tools/call` executes
- [ ] New tests added for changed code (protocol wiring remains covered by the existing tool-module suites; the server has never had transport-level tests)
- [ ] Bundle sizes checked (browser bundles untouched — server-side package only)

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] Self-reviewed the diff
- [x] No `any` types introduced without justification (one documented `as unknown as Tool[]` cast bridging the framework's wider `MCPToolDefinition` to the SDK's `JSONValue`-typed schema)
- [x] No security issues (eval, innerHTML with user input, exposed secrets)
- [x] Documentation updated if public APIs changed (README protocol-support section, CHANGELOG entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTeAXu12nEBRGEgBzJiDn2

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTeAXu12nEBRGEgBzJiDn2)_