### PR TITLE
feat(htmx-adapter): cancel v4 hx-on binding instead of removing attrs; fix modifier-suffix + trigger-split gaps

### DIFF
--- a/packages/htmx-adapter/CLAUDE.md
+++ b/packages/htmx-adapter/CLAUDE.md
@@ -64,14 +64,31 @@ npm run build              # ESM + CJS + browser IIFE (~2 KB gz)
   flips the hx-on family into executor mode — the adapter claims every
   hx-on attr (listener install; claims deduped per element by resolved
   event name), suppresses canonical-sibling creation for localized names,
-  and REMOVES canonical-named `hx-on:*` attrs so htmx never JS-evals a
-  hyperscript body. Bodies translate lazily (first fire, memoized) via
+  and keeps htmx from JS-evaling canonical-named `hx-on:*` bodies. HOW
+  depends on the claim mode (`registerWith` selects it): on v4
+  (`'preserve'`) the extension cancels the node's `htmx:before:on:init`
+  and the authored attr stays; on v2/unknown (`'remove'`, default) the
+  attr is removed after claiming. Removal survives on v4 only as a
+  per-node fallback for elements mixing claimed colon-forms with the
+  legacy composite `hx-on="…"` / `data-hx-on*` forms htmx must still
+  bind. Bodies translate lazily (first fire, memoized) via
   `setBodyTranslator()` (auto-detected from `HyperscriptI18n.preprocess`).
-- **Two authored-attribute mutations, both documented**: `hx-trigger`
-  in-place value translation (localized event values in a canonical attr
-  have no separate canonical target; idempotent by construction), and
-  executor-mode removal of canonical-named `hx-on:*` (double-execution
-  guard).
+- **Authored-attribute mutations, all documented**: `hx-trigger` in-place
+  value translation (localized event values in a canonical attr have no
+  separate canonical target; idempotent by construction — covers the
+  `hx-trigger:inherited`/`:append` modifier forms too), plus the
+  executor-mode removal cases above (v2 always; v4 mixed nodes only).
+- **Trigger-spec grammar mirrors core**: `translateTriggerValue` splits
+  specs with a byte-mirror of htmx v4's `HCON.split` top-level-comma
+  regex (commas inside `[filters]`, `(calls)`, and quoted strings are
+  not separators), and returns the input verbatim when nothing
+  translates. Non-`hx-on` colon suffixes (`:inherited`/`:append`) pass
+  through as modifiers — never through the events map.
+- **No extension `init(internalAPI)`, deliberately**: `parseTriggerSpecs`
+  is parse-only (no serializer — round-tripping would couple us to a
+  hand-written htmx-spec serializer) and `attributeValue`'s
+  inheritance-aware reads buy nothing for a sweep that must visit every
+  element anyway. Rationale recorded in extension.ts.
 - **Zero workspace deps** — builds standalone anywhere in CI's build order.
 
 ## Load order (matters)

--- a/packages/htmx-adapter/README.md
+++ b/packages/htmx-adapter/README.md
@@ -61,9 +61,13 @@ Guarantees, mirroring loka-js where the mechanism allows:
   the author wrote. Two documented exceptions: an author-written canonical
   `hx-trigger` whose _value_ uses localized event names (`hx-trigger="clic"`)
   is translated in place (idempotently), since there is no separate canonical
-  target; and canonical-named `hx-on:*` attrs are removed in opt-in executor
-  mode (see below), since htmx would otherwise JS-eval their hyperscript
-  bodies.
+  target; and in opt-in executor mode on htmx **v2**, canonical-named
+  `hx-on:*` attrs are removed, since htmx would otherwise JS-eval their
+  hyperscript bodies. On htmx **v4** even that exception disappears: the
+  extension cancels the node's `htmx:before:on:init` instead, so claimed
+  `hx-on:*` attrs stay authored-verbatim (the removal survives only as a
+  per-node fallback when the element also carries the legacy composite
+  `hx-on="…"` or a `data-hx-on*` spelling, which only htmx can bind).
 - **An existing canonical attribute always wins** — `hx-get` is never
   overwritten by `hx-obtener`.
 - **No vocab loaded → no-op.** Stock htmx pages pay nothing.
@@ -141,10 +145,16 @@ reliable detection):
   unchanged.
 - **Localized-named attrs** (`hx-en:clic`) stay verbatim in the DOM and get
   no canonical sibling — htmx never recognized them anyway.
-- **Canonical-named attrs** (`hx-on:click`) are **removed** after claiming —
-  the second (and last) documented exception to the never-mutate rule: left
-  in place, htmx would eval the hyperscript body as JS, giving a console
-  error plus a double-execution attempt on every fire.
+- **Canonical-named attrs** (`hx-on:click`) must be kept away from htmx's own
+  binder — left bound, htmx would eval the hyperscript body as JS, giving a
+  console error plus a double-execution attempt on every fire. On htmx **v4**
+  this costs no mutation: the extension cancels the node's cancelable
+  `htmx:before:on:init` hook and the authored attribute stays in the DOM. On
+  htmx **v2** (no such hook) the attr is **removed** after claiming — the
+  second documented exception to the never-mutate rule. The removal also
+  remains as a v4 per-node fallback when the element mixes claimed colon-form
+  attrs with the legacy composite `hx-on="event -> code"` (or `data-hx-on*`)
+  forms, which the adapter never claims and htmx must still bind.
 - The `hx-on::after-swap` shorthand maps to the `htmx:` event namespace and
   works unchanged (the listener hears htmx's real CustomEvents).
 - Re-sweeps never stack duplicate listeners (claims are keyed per element by

--- a/packages/htmx-adapter/docs/UPSTREAM_HOOK_PROPOSAL.md
+++ b/packages/htmx-adapter/docs/UPSTREAM_HOOK_PROPOSAL.md
@@ -31,7 +31,10 @@ with a prefixed spelling, and `#prefixes()` unions the prefixed forms into the
 compiled discovery selectors (`#actionSelector`, `#boostSelector`, the
 `#hxOnQuery` XPath). The resolver proposed here is a per-element
 generalization of that existing, shipped mechanism — not a new concept for
-core. A resolver consulted there enables, with zero cost when unset:
+core. There is precedent for the _extension-injects-policy_ shape too:
+`internalAPI.initSecurity` already lets an extension replace core's private
+`Function`/`AsyncFunction` constructors and Trusted Types policy — a far
+stronger injection than a read-only name resolver. A resolver consulted there enables, with zero cost when unset:
 
 - **Localized authoring** (our use case): `hx-obtener` read as `hx-get` for
   elements under `lang="es"`, resolved per element, with the DOM left exactly

--- a/packages/htmx-adapter/src/canonicalize.ts
+++ b/packages/htmx-adapter/src/canonicalize.ts
@@ -38,30 +38,36 @@ import { isResolverMode } from './resolver.js';
 const NS_RE = /^(?:hx|sse|ws)-/;
 
 /**
+ * Byte-mirror of htmx v4's `HCON.split` top-level-comma regex (vendored
+ * 4.0.0-beta5, `HCON.split`). Spec boundaries must match core's grammar:
+ * commas inside `[filters]`, `(calls)`, and quoted strings — e.g.
+ * `from:".a, .b"` — are NOT separators.
+ */
+const TOP_LEVEL_COMMA_RE = /,(?![^\[]*\])(?![^(]*\))(?![^<]*\/>)(?=(?:[^"']|"[^"]*"|'[^']*')*$)/;
+
+/**
  * Translate localized event names inside an `hx-trigger` value.
  *
  * hx-trigger grammar: comma-separated specs, each `eventName[filter]
  * modifier…`. Only the leading event token of each spec is translated
- * (preserving an attached `[...]` filter); modifiers like `delay:500ms`,
- * `from:body`, `once` are language-invariant and left alone. Unknown
- * tokens pass through untouched, which also makes translation idempotent
- * (the maps are localized → canonical only).
+ * (an attached `[...]` filter, all modifiers like `delay:500ms` /
+ * `from:body` / `once`, and the authored spacing stay byte-identical).
+ * When nothing translates, the original string is returned verbatim, so
+ * an all-canonical value is never rewritten. Unknown tokens pass
+ * through untouched, which also makes translation idempotent (the maps
+ * are localized → canonical only).
  */
 export function translateTriggerValue(value: string, events: Record<string, string>): string {
-  return value
-    .split(',')
-    .map(spec => {
-      const trimmed = spec.trim();
-      if (!trimmed) return trimmed;
-      const parts = trimmed.split(/\s+/);
-      const m = parts[0].match(/^([^[\s]+)(\[.*)?$/);
-      if (m) {
-        const translated = events[m[1]];
-        if (translated) parts[0] = translated + (m[2] ?? '');
-      }
-      return parts.join(' ');
+  let changed = false;
+  const specs = value.split(TOP_LEVEL_COMMA_RE).map(spec =>
+    spec.replace(/^(\s*)([^[\s]+)/, (whole, ws: string, evt: string) => {
+      const translated = events[evt];
+      if (!translated) return whole;
+      changed = true;
+      return ws + translated;
     })
-    .join(', ');
+  );
+  return changed ? specs.join(',') : value;
 }
 
 /**
@@ -114,8 +120,14 @@ export function canonicalizeElement(elt: Element): boolean {
     // Exact match: hx-obtener → hx-get.
     let canonical = attrs[name];
 
-    // Colon family (hx-on:*): hx-en:clic → hx-on:click. The base is
-    // looked up in attrs, the event suffix in events.
+    // Colon family: the base is looked up in attrs; what the suffix
+    // means depends on the base. For hx-on the suffix is an EVENT name
+    // (hx-en:clic → hx-on:click) and translates through events. For
+    // every other attribute a colon suffix is an htmx v4 MODIFIER
+    // (`:inherited` / `:append` — #attributeValue reads name+":inherited"
+    // etc.), never an event name: pass it through verbatim so e.g.
+    // hx-objetivo:inherited → hx-target:inherited, and an events-map
+    // collision can never corrupt the modifier.
     let colonBase: string | undefined;
     if (!canonical) {
       const colon = name.indexOf(':');
@@ -123,7 +135,10 @@ export function canonicalizeElement(elt: Element): boolean {
         colonBase = attrs[name.slice(0, colon)];
         if (colonBase) {
           const suffix = name.slice(colon + 1);
-          canonical = `${colonBase}:${events[suffix] ?? suffix}`;
+          canonical =
+            colonBase === 'hx-on'
+              ? `${colonBase}:${events[suffix] ?? suffix}`
+              : `${colonBase}:${suffix}`;
         }
       }
     }
@@ -141,20 +156,27 @@ export function canonicalizeElement(elt: Element): boolean {
     if (canonical === name || elt.hasAttribute(canonical)) continue;
 
     let value = attr.value;
-    if (canonical === 'hx-trigger') value = translateTriggerValue(value, events);
+    // hx-trigger and its modifier forms (hx-trigger:inherited etc.)
+    // carry event names in the VALUE — translate on the way over.
+    if (canonical === 'hx-trigger' || canonical.startsWith('hx-trigger:')) {
+      value = translateTriggerValue(value, events);
+    }
     elt.setAttribute(canonical, value);
     changed = true;
   }
 
-  // Author-written canonical hx-trigger with localized event values
+  // Author-written canonical hx-trigger (including modifier forms like
+  // hx-trigger:inherited) with localized event values
   // (`hx-trigger="clic"`). Translated in place — the only mutation of an
   // authored attribute, because there is no separate canonical target.
-  const trigger = elt.getAttribute('hx-trigger');
-  if (trigger !== null && Object.keys(events).length > 0) {
-    const translated = translateTriggerValue(trigger, events);
-    if (translated !== trigger) {
-      elt.setAttribute('hx-trigger', translated);
-      changed = true;
+  if (Object.keys(events).length > 0) {
+    for (const attr of Array.from(elt.attributes)) {
+      if (attr.name !== 'hx-trigger' && !attr.name.startsWith('hx-trigger:')) continue;
+      const translated = translateTriggerValue(attr.value, events);
+      if (translated !== attr.value) {
+        elt.setAttribute(attr.name, translated);
+        changed = true;
+      }
     }
   }
 

--- a/packages/htmx-adapter/src/extension.ts
+++ b/packages/htmx-adapter/src/extension.ts
@@ -11,7 +11,10 @@
  * init or hx-on binding, so canonicalizing in `htmx_before_process`
  * covers everything htmx will read. `htmx_before_process_node` is kept
  * as a defensive alias for other v4 prereleases that used per-node
- * naming; an unmatched key is inert.
+ * naming; an unmatched key is inert. The cancelable
+ * `htmx_before_on_init` hook (fires per hx-on-carrying node, after
+ * before:process) lets executor mode keep claimed `hx-on:*` attributes
+ * in the DOM instead of removing them — see createExtension.
  *
  * A v2 fallback (`htmx.defineExtension` + `onEvent('htmx:beforeProcessNode')`)
  * is included because the localized attribute names are version-agnostic
@@ -27,7 +30,8 @@
 
 import { canonicalizeTree } from './canonicalize.js';
 import { onVocabUpdate } from './registry.js';
-import { onBodyHooksChanged } from './hx-on.js';
+import { hasBodyExecutor, onBodyHooksChanged, setCanonicalClaimMode } from './hx-on.js';
+import { isResolverMode } from './resolver.js';
 
 export const EXTENSION_NAME = 'lokascript-i18n';
 
@@ -42,6 +46,15 @@ export interface HtmxLike {
 /**
  * Build the extension object. v4 hooks and the v2 `onEvent` callback are
  * both present — each API only reads the members it knows about.
+ *
+ * Deliberately NO `init(internalAPI)`: the members v4 passes there were
+ * each evaluated and rejected. `parseTriggerSpecs` is parse-only (no
+ * serializer), so translating `hx-trigger` values through it would mean
+ * writing our own htmx-spec serializer — worse coupling than mirroring
+ * core's top-level-split grammar in canonicalize.ts. `attributeValue`
+ * adds inheritance-aware reads, but the sweep must canonicalize every
+ * element (ancestors included) regardless of inheritance, so it buys
+ * nothing. Re-evaluate if v4 ever passes a write/interception surface.
  */
 export function createExtension(): object {
   return {
@@ -53,6 +66,32 @@ export function createExtension(): object {
     // Defensive alias for v4 prereleases with per-node hook naming.
     htmx_before_process_node(elt: Element): void {
       canonicalizeTree(elt);
+    },
+    // htmx v4 (verified on 4.0.0-beta5): fires per node carrying an
+    // hx-on-family attribute, cancelable — returning false makes htmx
+    // skip JS-binding that node entirely. In executor mode this is the
+    // zero-mutation double-execution guard: claimed `hx-on:*` bodies
+    // stay authored-verbatim in the DOM and htmx simply never binds
+    // them. (`registerWith` flips the claim mode to 'preserve' on v4 so
+    // claims stop removing the attribute.)
+    htmx_before_on_init(elt: Element): boolean | undefined {
+      if (!hasBodyExecutor() || isResolverMode()) return undefined;
+      const names = elt.getAttributeNames();
+      // v4 also binds forms the adapter never claims: the legacy
+      // composite `hx-on="event -> code"` and every `data-hx-on*`
+      // spelling. On such mixed nodes fall back to removing the claimed
+      // colon-form attrs so htmx still binds the unclaimed forms
+      // without JS-evaling a hyperscript body.
+      if (names.some(n => n === 'hx-on' || n.startsWith('data-hx-on'))) {
+        for (const n of names) {
+          if (n.startsWith('hx-on:')) elt.removeAttribute(n);
+        }
+        return undefined;
+      }
+      // Every htmx-bindable hx-on attr on this node is the claimed
+      // colon form — cancel htmx's binding outright.
+      if (names.some(n => n.startsWith('hx-on:'))) return false;
+      return undefined;
     },
     // htmx v1/v2 fallback: single event dispatcher.
     onEvent(name: string, evt: CustomEvent & { target?: EventTarget | null }): void {
@@ -73,10 +112,18 @@ export function registerWith(htmx: HtmxLike | undefined | null): 'v4' | 'v2' | n
   const ext = createExtension();
   if (typeof htmx.registerExtension === 'function') {
     htmx.registerExtension(EXTENSION_NAME, ext);
+    // v4's cancelable before:on:init hook is the double-execution
+    // guard, so executor-mode claims can leave canonical hx-on:* attrs
+    // authored-verbatim. In browser.ts both registration paths (sync
+    // and the DOMContentLoaded retry) run before the first sweep, so
+    // the mode is set before any claim happens.
+    setCanonicalClaimMode('preserve');
     return 'v4';
   }
   if (typeof htmx.defineExtension === 'function') {
     htmx.defineExtension(EXTENSION_NAME, ext);
+    // v2 has no cancelable per-node hx-on hook — removal stays the guard.
+    setCanonicalClaimMode('remove');
     return 'v2';
   }
   return null;

--- a/packages/htmx-adapter/src/hx-on.ts
+++ b/packages/htmx-adapter/src/hx-on.ts
@@ -19,11 +19,14 @@
  * - Localized-named attrs (`hx-en:clic`) stay verbatim in the DOM — htmx
  *   never recognized them anyway — and NO canonical `hx-on:*` sibling is
  *   created.
- * - Canonical-named attrs (`hx-on:click`) are REMOVED after claiming.
- *   This is the one place the adapter deletes an authored attribute: if
- *   it stayed, htmx would eval the hyperscript body as JS — a console
- *   error plus a double-execution attempt on every fire. Documented as
- *   the executor-mode exception in the README.
+ * - Canonical-named attrs (`hx-on:click`) must be kept away from htmx's
+ *   own binder: if htmx bound them, it would eval the hyperscript body
+ *   as JS — a console error plus a double-execution attempt on every
+ *   fire. HOW they are kept away depends on the claim mode below: on
+ *   htmx v4 the extension cancels the node's `htmx:before:on:init` and
+ *   the authored attribute stays ('preserve'); everywhere else the
+ *   attribute is removed after claiming ('remove', the default) —
+ *   documented as the executor-mode exception in the README.
  *
  * With no executor set (the default), none of this runs and bodies keep
  * upstream JS semantics — the behavior-preservation invariant.
@@ -54,6 +57,31 @@ const hookChangeListeners = new Set<() => void>();
  * DOM attribute order decides which body wins.
  */
 let claimed = new WeakMap<Element, Set<string>>();
+
+/**
+ * What happens to a canonical-named `hx-on:*` attribute when claimed.
+ *
+ * - `'remove'` (default): delete it, so htmx can never JS-eval the
+ *   hyperscript body. The only guard available on htmx v2 / unknown
+ *   runtimes, at the cost of mutating an authored attribute.
+ * - `'preserve'`: leave the authored attribute in the DOM. Correct ONLY
+ *   when the v4 extension is registered — its cancelable
+ *   `htmx:before:on:init` hook stops htmx from binding the node instead
+ *   (see extension.ts). registerWith() selects the mode from which htmx
+ *   API accepted the extension, before any claims happen in the
+ *   recommended load order.
+ */
+export type CanonicalClaimMode = 'remove' | 'preserve';
+
+let claimMode: CanonicalClaimMode = 'remove';
+
+export function setCanonicalClaimMode(mode: CanonicalClaimMode): void {
+  claimMode = mode;
+}
+
+export function canonicalClaimMode(): CanonicalClaimMode {
+  return claimMode;
+}
 
 /** Configure the body executor. Setting/clearing it notifies subscribers. */
 export function setBodyExecutor(fn: BodyExecutor | null): void {
@@ -115,10 +143,11 @@ export function claimHxOnAttribute(
   const eventName = eventNameForSuffix(attrName.slice(colon + 1), events);
   const already = claimed.get(elt);
   if (already?.has(eventName)) {
-    // Duplicate claim for an already-claimed event — no second listener,
-    // but canonical-named attrs still get neutralized so htmx never
-    // JS-evals them.
-    if (attrName.startsWith('hx-on:') && elt.hasAttribute(attrName)) {
+    // Duplicate claim for an already-claimed event — no second listener.
+    // In 'remove' mode canonical-named attrs still get neutralized so
+    // htmx never JS-evals them; in 'preserve' mode the v4
+    // before:on:init cancellation is the guard and the attribute stays.
+    if (claimMode === 'remove' && attrName.startsWith('hx-on:') && elt.hasAttribute(attrName)) {
       elt.removeAttribute(attrName);
       return true;
     }
@@ -144,10 +173,12 @@ export function claimHxOnAttribute(
     }
   });
 
-  // Canonical-named claims are removed so htmx never JS-evals the
-  // hyperscript body (double-execution guard). Localized names are
-  // invisible to htmx and stay verbatim.
-  if (attrName.startsWith('hx-on:')) elt.removeAttribute(attrName);
+  // In 'remove' mode canonical-named claims are deleted so htmx never
+  // JS-evals the hyperscript body (double-execution guard); in
+  // 'preserve' mode (v4) the attribute stays and the extension cancels
+  // htmx's binding instead. Localized names are invisible to htmx and
+  // always stay verbatim.
+  if (claimMode === 'remove' && attrName.startsWith('hx-on:')) elt.removeAttribute(attrName);
 
   if (already) {
     already.add(eventName);
@@ -194,4 +225,5 @@ export function resetBodyHooks(): void {
   translator = null;
   hookChangeListeners.clear();
   claimed = new WeakMap();
+  claimMode = 'remove';
 }

--- a/packages/htmx-adapter/test/browser/adapter.spec.ts
+++ b/packages/htmx-adapter/test/browser/adapter.spec.ts
@@ -74,10 +74,13 @@ test.describe('htmx v4 (4.0.0-beta5)', () => {
   }) => {
     await page.goto(`${FIXTURES}/v4-hx-on.html`);
 
-    // Canonical-named claim: attribute removed (htmx must not JS-eval it),
-    // body executed by _hyperscript with `me` = the button.
+    // Canonical-named claim on v4: the authored attribute is PRESERVED —
+    // the cancelable before:on:init hook keeps htmx from JS-evaling it,
+    // so no mutation is needed. Body executed by _hyperscript with
+    // `me` = the button; the toggle-on/toggle-off pair below doubles as
+    // the double-execution probe (two executions would cancel out).
     const canonical = page.locator('#canonical');
-    await expect(canonical).not.toHaveAttribute('hx-on:click', /./);
+    await expect(canonical).toHaveAttribute('hx-on:click', 'toggle .marcado on me');
     await canonical.click();
     await expect(canonical).toHaveClass(/marcado/);
     await canonical.click();
@@ -102,6 +105,27 @@ test.describe('htmx v4 (4.0.0-beta5)', () => {
     page.on('pageerror', err => errors.push(String(err)));
     await canonical.click();
     expect(errors).toEqual([]);
+  });
+
+  test('executor mode: mixed node — composite hx-on stays with htmx, colon form with the executor', async ({
+    page,
+  }) => {
+    await page.goto(`${FIXTURES}/v4-hx-on.html`);
+    const mixed = page.locator('#mixto');
+
+    // On a node that also carries the legacy composite form, per-node
+    // cancellation would kill htmx's composite binding too — so the
+    // adapter falls back to removing the claimed colon-form attr and
+    // lets htmx proceed.
+    await expect(mixed).not.toHaveAttribute('hx-on:click', /./);
+    await expect(mixed).toHaveAttribute('hx-on', /blur/);
+
+    await mixed.click(); // executor path (claimed body)
+    await expect(mixed).toHaveClass(/marcado/);
+
+    await mixed.focus();
+    await mixed.blur(); // htmx's own JS path (composite body)
+    await expect(mixed).toHaveClass(/js-blur/);
   });
 });
 

--- a/packages/htmx-adapter/test/browser/fixtures/v4-hx-on.html
+++ b/packages/htmx-adapter/test/browser/fixtures/v4-hx-on.html
@@ -20,13 +20,25 @@
   </head>
   <body>
     <!-- English hyperscript body under a canonical name, in an explicit
-         en scope (the page is lang="es"): executor mode must claim it
-         (attribute removed) or htmx v4 evals it as JS — and must NOT
-         route an en-scope body through the translator. -->
+         en scope (the page is lang="es"): executor mode must claim it and
+         keep htmx v4 from JS-evaling it — on v4 via the cancelable
+         before:on:init hook, with the authored attribute PRESERVED — and
+         must NOT route an en-scope body through the translator. -->
     <div data-hyperfixi-lang="en">
       <button id="canonical" hx-on:click="toggle .marcado on me">canonical</button>
     </div>
     <!-- Localized name + localized hyperscript body: listener + translator. -->
     <button id="localizado" hx-en:clic="alternar .activo">localizado</button>
+    <!-- Mixed node: a claimed colon-form PLUS the legacy composite form,
+         which only htmx can bind. The adapter must fall back to removing
+         the claimed attr on this node so htmx still binds the composite
+         (per-node cancellation would kill both). -->
+    <button
+      id="mixto"
+      hx-on:click="toggle .marcado on me"
+      hx-on="blur -> event.target.classList.add('js-blur')"
+    >
+      mixto
+    </button>
   </body>
 </html>

--- a/packages/htmx-adapter/test/canonicalize.test.ts
+++ b/packages/htmx-adapter/test/canonicalize.test.ts
@@ -46,8 +46,8 @@ describe('translateTriggerValue', () => {
   });
 
   it('preserves attached filters and modifiers', () => {
-    expect(translateTriggerValue("clic[ctrlKey] delay:500ms", events)).toBe(
-      "click[ctrlKey] delay:500ms"
+    expect(translateTriggerValue('clic[ctrlKey] delay:500ms', events)).toBe(
+      'click[ctrlKey] delay:500ms'
     );
   });
 
@@ -55,6 +55,26 @@ describe('translateTriggerValue', () => {
     expect(translateTriggerValue('every 2s', events)).toBe('every 2s');
     const once = translateTriggerValue('clic delay:500ms', events);
     expect(translateTriggerValue(once, events)).toBe(once);
+  });
+
+  it('does not split inside quoted from: selectors (HCON top-level grammar)', () => {
+    expect(translateTriggerValue('clic from:".a, .b"', events)).toBe('click from:".a, .b"');
+  });
+
+  it('does not split inside filter brackets or parens', () => {
+    expect(translateTriggerValue('clic[foo(a,b)], cambiar', events)).toBe(
+      'click[foo(a,b)], change'
+    );
+  });
+
+  it('returns the original string verbatim when nothing translates', () => {
+    // No whitespace normalization on all-canonical values — an authored
+    // attribute must never be rewritten without an actual translation.
+    expect(translateTriggerValue('click ,keyup', events)).toBe('click ,keyup');
+  });
+
+  it('preserves authored spacing around translated tokens', () => {
+    expect(translateTriggerValue('clic ,  teclaabajo', events)).toBe('click ,  keydown');
   });
 });
 
@@ -91,6 +111,53 @@ describe('canonicalizeElement', () => {
     canonicalizeElement(btn);
     expect(btn.getAttribute('hx-on:click')).toBe('console.log(1)');
     expect(btn.getAttribute('hx-en:clic')).toBe('console.log(1)');
+  });
+
+  it('maps a localized attr with a modifier suffix to the canonical modifier form', () => {
+    register('es', ES);
+    document.body.innerHTML = `<section lang="es" hx-objetivo:inherited="#out"><button hx-obtener="/x"></button></section>`;
+    const sec = document.querySelector('section')!;
+    expect(canonicalizeElement(sec)).toBe(true);
+    expect(sec.getAttribute('hx-target:inherited')).toBe('#out');
+    expect(sec.getAttribute('hx-objetivo:inherited')).toBe('#out'); // authored stays
+  });
+
+  it('translates event values when creating hx-trigger modifier forms', () => {
+    register('es', ES);
+    document.body.innerHTML = `<section lang="es" hx-disparar:inherited="clic"><button hx-obtener="/x"></button></section>`;
+    const sec = document.querySelector('section')!;
+    canonicalizeElement(sec);
+    expect(sec.getAttribute('hx-trigger:inherited')).toBe('click');
+  });
+
+  it('never routes a non-hx-on suffix through the events map (collision-proof)', () => {
+    register('xx', {
+      hyperfixi: {
+        attrs: { 'hx-blanco': 'hx-target' },
+        // Adversarial vocab: an event key that collides with the
+        // canonical modifier word. The modifier must pass through.
+        events: { inherited: 'click' },
+      },
+    });
+    document.body.innerHTML = `<section lang="xx" hx-blanco:inherited="#out"><button hx-blanco="#x"></button></section>`;
+    const sec = document.querySelector('section')!;
+    canonicalizeElement(sec);
+    expect(sec.getAttribute('hx-target:inherited')).toBe('#out');
+    expect(sec.hasAttribute('hx-target:click')).toBe(false);
+  });
+
+  it('translates an authored canonical hx-trigger:inherited value in place', () => {
+    register('es', ES);
+    const btn = esButton(`hx-trigger:inherited="clic"`);
+    expect(canonicalizeElement(btn)).toBe(true);
+    expect(btn.getAttribute('hx-trigger:inherited')).toBe('click');
+  });
+
+  it('handles the chained :inherited:append modifier suffix', () => {
+    register('es', ES);
+    const btn = esButton(`hx-disparar:inherited:append="clic"`);
+    canonicalizeElement(btn);
+    expect(btn.getAttribute('hx-trigger:inherited:append')).toBe('click');
   });
 
   it('never overwrites an existing canonical attribute', () => {

--- a/packages/htmx-adapter/test/extension.test.ts
+++ b/packages/htmx-adapter/test/extension.test.ts
@@ -6,6 +6,12 @@ import {
   registerWith,
   installAutoSweep,
 } from '../src/extension.js';
+import {
+  setBodyExecutor,
+  resetBodyHooks,
+  setCanonicalClaimMode,
+  canonicalClaimMode,
+} from '../src/hx-on.js';
 
 const ES = {
   hyperfixi: {
@@ -16,6 +22,7 @@ const ES = {
 
 beforeEach(() => {
   resetRegistry();
+  resetBodyHooks();
   document.body.innerHTML = '';
 });
 
@@ -38,6 +45,104 @@ describe('registerWith', () => {
     expect(registerWith(null)).toBeNull();
     expect(registerWith(undefined)).toBeNull();
     expect(registerWith({})).toBeNull();
+  });
+});
+
+describe('registerWith selects the canonical claim mode', () => {
+  it("v4 → 'preserve' (the cancelable before:on:init hook is the guard)", () => {
+    registerWith({ registerExtension: vi.fn() });
+    expect(canonicalClaimMode()).toBe('preserve');
+  });
+
+  it("v2 → 'remove' (no cancelable per-node hx-on hook exists)", () => {
+    registerWith({ defineExtension: vi.fn() });
+    expect(canonicalClaimMode()).toBe('remove');
+  });
+});
+
+describe('v4 hook: htmx_before_on_init (executor double-execution guard)', () => {
+  type Ext = {
+    htmx_before_process(elt: Element): void;
+    htmx_before_on_init(elt: Element): boolean | undefined;
+  };
+
+  it('is inert without an executor — htmx binds hx-on itself', () => {
+    const ext = createExtension() as Ext;
+    document.body.innerHTML = `<button hx-on:click="doIt()"></button>`;
+    const btn = document.querySelector('button')!;
+    expect(ext.htmx_before_on_init(btn)).toBeUndefined();
+    expect(btn.getAttribute('hx-on:click')).toBe('doIt()');
+  });
+
+  it('cancels binding when every hx-on attr is the claimed colon form; attrs stay', () => {
+    setCanonicalClaimMode('preserve');
+    const executor = vi.fn();
+    setBodyExecutor(executor);
+    const ext = createExtension() as Ext;
+    document.body.innerHTML = `<button hx-on:click="toggle .x"></button>`;
+    const btn = document.querySelector('button')!;
+
+    ext.htmx_before_process(document.body); // the sweep that claims
+    expect(btn.getAttribute('hx-on:click')).toBe('toggle .x'); // preserved
+
+    expect(ext.htmx_before_on_init(btn)).toBe(false); // htmx skips the node
+    expect(btn.getAttribute('hx-on:click')).toBe('toggle .x'); // still preserved
+
+    btn.dispatchEvent(new Event('click', { bubbles: true }));
+    expect(executor).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to removal on a mixed node (legacy composite hx-on) and lets htmx proceed', () => {
+    setCanonicalClaimMode('preserve');
+    setBodyExecutor(vi.fn());
+    const ext = createExtension() as Ext;
+    document.body.innerHTML = `<button hx-on:click="toggle .x" hx-on="blur -> doB()"></button>`;
+    const btn = document.querySelector('button')!;
+
+    ext.htmx_before_process(document.body);
+    expect(ext.htmx_before_on_init(btn)).toBeUndefined(); // htmx proceeds (composite)
+    expect(btn.hasAttribute('hx-on:click')).toBe(false); // claimed form removed
+    expect(btn.getAttribute('hx-on')).toBe('blur -> doB()'); // untouched for htmx
+  });
+
+  it('data-hx-on* spellings also take the removal fallback', () => {
+    setCanonicalClaimMode('preserve');
+    setBodyExecutor(vi.fn());
+    const ext = createExtension() as Ext;
+    document.body.innerHTML = `<button hx-on:click="toggle .x" data-hx-on:change="js()"></button>`;
+    const btn = document.querySelector('button')!;
+
+    ext.htmx_before_process(document.body);
+    expect(ext.htmx_before_on_init(btn)).toBeUndefined();
+    expect(btn.hasAttribute('hx-on:click')).toBe(false);
+    expect(btn.getAttribute('data-hx-on:change')).toBe('js()');
+  });
+
+  it('leaves nodes without hx-on attributes alone', () => {
+    setBodyExecutor(vi.fn());
+    const ext = createExtension() as Ext;
+    document.body.innerHTML = `<button hx-get="/x"></button>`;
+    expect(ext.htmx_before_on_init(document.querySelector('button')!)).toBeUndefined();
+  });
+
+  it('full v4 flow: registerWith flips the mode, sweep preserves, hook cancels', () => {
+    let captured: Ext | undefined;
+    registerWith({
+      registerExtension: (_name: string, ext: object) => {
+        captured = ext as Ext;
+      },
+    });
+    const executor = vi.fn();
+    setBodyExecutor(executor);
+    document.body.innerHTML = `<button hx-on:click="toggle .x"></button>`;
+    const btn = document.querySelector('button')!;
+
+    captured!.htmx_before_process(document.body);
+    expect(btn.getAttribute('hx-on:click')).toBe('toggle .x');
+    expect(captured!.htmx_before_on_init(btn)).toBe(false);
+
+    btn.dispatchEvent(new Event('click', { bubbles: true }));
+    expect(executor).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/htmx-adapter/test/hx-on.test.ts
+++ b/packages/htmx-adapter/test/hx-on.test.ts
@@ -8,6 +8,8 @@ import {
   hasBodyTranslator,
   autoDetectBodyHooks,
   resetBodyHooks,
+  setCanonicalClaimMode,
+  canonicalClaimMode,
 } from '../src/hx-on.js';
 import { installAutoSweep } from '../src/extension.js';
 
@@ -139,6 +141,48 @@ describe('executor mode: canonical-named hx-on', () => {
     btn.dispatchEvent(new Event('change'));
     expect(executor).toHaveBeenCalledTimes(2);
     expect(executor.mock.calls.map(c => c[0]).sort()).toEqual(['a', 'b']);
+  });
+});
+
+describe("executor mode: 'preserve' claim mode (htmx v4)", () => {
+  it('claims WITHOUT removing the canonical attribute; listener still fires once', () => {
+    setCanonicalClaimMode('preserve');
+    const executor = vi.fn();
+    setBodyExecutor(executor);
+    document.body.innerHTML = `<button hx-on:click="toggle .active"></button>`;
+    const btn = document.querySelector('button')!;
+
+    expect(canonicalizeElement(btn)).toBe(true);
+    expect(btn.getAttribute('hx-on:click')).toBe('toggle .active'); // authored-verbatim
+
+    canonicalizeElement(btn); // re-sweep: dedupe path must not remove either
+    expect(btn.getAttribute('hx-on:click')).toBe('toggle .active');
+
+    click(btn);
+    expect(executor).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps BOTH authored attrs when localized and canonical name the same event', () => {
+    register('es', ES);
+    setCanonicalClaimMode('preserve');
+    const executor = vi.fn();
+    setBodyExecutor(executor);
+    document.body.innerHTML = `<section lang="es"><button hx-en:clic="a" hx-on:click="b"></button></section>`;
+    const btn = document.querySelector('button')!;
+
+    canonicalizeElement(btn);
+    expect(btn.getAttribute('hx-en:clic')).toBe('a');
+    expect(btn.getAttribute('hx-on:click')).toBe('b');
+
+    click(btn);
+    expect(executor).toHaveBeenCalledTimes(1); // DOM attribute order decides the winner
+    expect(executor).toHaveBeenCalledWith('a', btn, expect.any(Event));
+  });
+
+  it('resetBodyHooks restores the remove default', () => {
+    setCanonicalClaimMode('preserve');
+    resetBodyHooks();
+    expect(canonicalClaimMode()).toBe('remove');
   });
 });
 


### PR DESCRIPTION
## Summary

Two refinements from auditing what htmx v4 (4.0.0-beta5) actually offers extensions, plus one recorded rejection.

### 1. Executor mode on v4 no longer mutates authored `hx-on:*` attributes

v4 fires a **cancelable** `htmx:before:on:init` per hx-on-carrying node — returning `false` makes htmx skip JS-binding the node entirely. That replaces the removal-based double-execution guard:

- `registerWith()` flips a claim mode to `'preserve'` when the v4 API accepts the extension — verified to happen before the first sweep in every load path (sync registration; the DOMContentLoaded retry listener registers ahead of the sweep listener).
- The new `htmx_before_on_init` hook cancels nodes whose hx-on attrs are all claimed colon-forms: the authored attribute stays in the DOM, htmx never binds it.
- **Mixed-node guard**: v4 also binds the legacy composite `hx-on="event -> code"` and `data-hx-on*` spellings, which the adapter never claims — and the hook cancels per-node, not per-attribute. Such nodes fall back to the old removal so htmx still binds the unclaimed forms.
- v2 keeps removal as the default (`'remove'`) — it has no cancelable per-node hook.

On v4 the adapter's only remaining authored-attribute mutations are the in-place `hx-trigger` value translation and the mixed-node fallback — which sharpens the upstream Discussion draft's pitch.

### 2. Canonicalization gaps found during the internalAPI audit

- **Modifier suffixes**: `hx-disparar:inherited="clic"` produced `hx-trigger:inherited` with the event value *untranslated* (htmx would bind a nonexistent `clic` event), and non-`hx-on` colon suffixes routed through the events map, where a vocab collision could corrupt `:inherited`. Fixed: non-`hx-on` suffixes pass through verbatim as modifiers; `hx-trigger:*` forms get value translation both when creating the canonical sibling and in place.
- **Trigger-spec splitting now mirrors core's grammar**: `translateTriggerValue` splits with a byte-mirror of htmx's `HCON.split` top-level-comma regex (commas inside `[filters]`, `(calls)`, and quoted `from:".a, .b"` selectors are not separators) and returns the input verbatim when nothing translates — no more whitespace rewrites of all-canonical authored values.

### Rejected after evaluation (rationale recorded in extension.ts)

Implementing `init(internalAPI)`: `parseTriggerSpecs` is parse-only with no serializer (round-tripping would mean hand-writing an htmx-spec serializer — worse coupling than the regex mirror), and `attributeValue`'s inheritance-aware reads buy nothing for a sweep that must visit every element anyway.

## Testing

- Vitest **87/87** (27 new, including an adversarial events-map collision case and preserve-mode claim/dedupe coverage)
- Playwright e2e **8/8** against real vendored htmx 4.0.0-beta5 / 2.0.10 / _hyperscript 0.9.93 — the canonical-attr assertion now pins *preservation* (body executed exactly once via the toggle-pair probe), plus a new mixed-node case proving htmx still binds the composite form after the fallback
- `tsc --noEmit` clean

Docs updated: README never-mutate guarantees, package CLAUDE.md, and the upstream proposal doc gains the `internalAPI.initSecurity` prior-art argument (core already lets extensions replace its private `Function` constructor and Trusted Types policy — a read-only name resolver is a milder ask).

🤖 Generated with [Claude Code](https://claude.com/claude-code)