### PR TITLE
fix(hyperscript-adapter): warn once per lang, drop the marker attribute, deprecate inert fallbackToOriginal

### DIFF
--- a/packages/hyperscript-adapter/CLAUDE.md
+++ b/packages/hyperscript-adapter/CLAUDE.md
@@ -36,7 +36,8 @@ test/
 ├── slim-preprocessor.test.ts  # Per-language bundle path integration
 ├── hyperscript-renderer.test.ts  # Custom renderer unit tests
 ├── language-resolver.test.ts  # DOM attribute resolution
-├── plugin.test.ts             # Plugin registration and behavior
+├── plugin.test.ts             # Plugin registration, warn-once, serialize→reparse behavior
+├── attribute-translator.test.ts  # Hook seam: WeakSet idempotency, zero DOM mutation
 ├── derive-syntax.test.ts      # Drift gate: generated syntax-table vs schemas
 └── browser/                   # Playwright e2e against the REAL _hyperscript runtime
     ├── adapter.spec.ts        # Localized toggles/add/put/remove across 8 languages + inheritance
@@ -50,7 +51,7 @@ demo/
 
 ```bash
 npm run typecheck          # TypeScript validation
-npm run test:run           # Vitest (209 tests, jsdom environment)
+npm run test:run           # Vitest (221 tests, jsdom environment)
 npm run test:browser       # Playwright e2e vs real vendored _hyperscript (build dist first)
 npm run build              # ESM + CJS + browser IIFEs (prebuild regenerates syntax-table)
 npm run generate:syntax    # Regenerate src/generated/syntax-table.ts after schema changes
@@ -65,7 +66,10 @@ The e2e suite serves the repo root on port **3010** (core's Playwright uses
 - **Preprocessor, not AST mapping**: \_hyperscript AST nodes are closure objects tightly coupled to the parser — reproducing them from semantic data would mean reimplementing every command parser
 - **Custom English renderer**: Per-language bundles use `hyperscript-renderer.ts` to render SemanticNodes to English \_hyperscript strings without needing English language data (tokenizer, profile, patterns), saving ~26 KB per bundle
 - **Two preprocessor paths**: `preprocessor.ts` (full, imports `@lokascript/semantic`) for the all-language bundle; `slim-preprocessor.ts` (imports `@lokascript/semantic/core` + custom renderer) for per-language bundles. Known divergence risk: the two paths render through different renderers and share no parity test yet
-- **Confidence gating**: semantic analysis below threshold falls through to original text, avoiding bad translations
+- **Confidence gating**: semantic analysis below threshold falls through to original text, avoiding bad translations. This also makes re-processing safe: already-translated English fed back through translation is an identity no-op
+- **WeakSet idempotency, zero DOM mutation**: the attribute translator tracks processed elements in a module-level `WeakSet` instead of stamping a marker attribute — devtools/serialization show exactly what the author wrote. A serialize→reparse round-trip produces new elements that are re-processed, which the confidence gate makes harmless (tested)
+- **Warn once per language**: an unchanged translation is often legitimate (canonical-English hyperscript under a non-en lang scope), so the full plugin warns once per language per page load (mirroring htmx-adapter's `warnMissingLangOnce`); `{ debug: true }` gives per-element detail. `resetTranslationWarnings()` resets the once-state (mainly for tests)
+- **`fallbackToOriginal` is deprecated and inert**: it never did anything — the preprocessor's string contract always returns the original source on failure. Kept in the type for compile compatibility; ignored at runtime
 - **Generated SYNTAX table**: `src/generated/syntax-table.ts` derives from semantic's command schemas (`derive-syntax.test.ts` is the drift gate). Trap: the file is tracked but matches `.gitignore`, so restaging needs `git add -f` and that commit `--no-verify` (root CLAUDE.md, gate #2)
 - **Bundle sizes (2026-08-06, minified/gzipped)**: full ~975/197 KB, per-language ~250–270/~68 KB, lite ~3/1.3 KB (expects an external semantic global)
 

--- a/packages/hyperscript-adapter/src/attribute-translator.ts
+++ b/packages/hyperscript-adapter/src/attribute-translator.ts
@@ -23,10 +23,15 @@ export interface HyperscriptHost {
   config?: { attributes?: string };
 }
 
-/** Marks an element as already translated so a later `processNode()` call over
- *  the same subtree (e.g. a sibling swap re-scanning a shared ancestor) doesn't
- *  re-translate already-English text as if it were still the original language. */
-const TRANSLATED_MARKER = 'data-hyperscript-i18n-translated';
+/** Elements already processed, so a later `processNode()` call over the same
+ *  subtree (e.g. a sibling swap re-scanning a shared ancestor) doesn't
+ *  re-translate already-English text as if it were still the original language.
+ *  A WeakSet instead of a marker attribute: the same idempotency with zero DOM
+ *  mutation (devtools/serialization show exactly what the author wrote).
+ *  Serialize→reparse (e.g. an innerHTML round-trip) produces NEW elements that
+ *  are re-processed — safe, because re-translating already-English text is
+ *  confidence-gated into a no-op. */
+const processed = new WeakSet<Element>();
 
 function scriptAttributeNames(hs: HyperscriptHost): string[] {
   const raw = hs.config?.attributes ?? '_, script, data-script';
@@ -68,13 +73,13 @@ export function installAttributeTranslator(
   const selector = [...attrNames.map(a => `[${a}]`), 'script[type="text/hyperscript"]'].join(', ');
 
   const translateOne = (elt: Element): void => {
-    if (elt.hasAttribute(TRANSLATED_MARKER)) return;
+    if (processed.has(elt)) return;
 
     if (elt instanceof HTMLScriptElement && elt.type === 'text/hyperscript') {
       const src = elt.textContent ?? '';
       if (!src) return;
       const english = translate(src, elt);
-      elt.setAttribute(TRANSLATED_MARKER, '');
+      processed.add(elt);
       if (english != null && english !== src) elt.textContent = english;
       return;
     }
@@ -84,7 +89,7 @@ export function installAttributeTranslator(
     const src = elt.getAttribute(attr);
     if (!src) return;
     const english = translate(src, elt);
-    elt.setAttribute(TRANSLATED_MARKER, '');
+    processed.add(elt);
     if (english != null && english !== src) elt.setAttribute(attr, english);
   };
 

--- a/packages/hyperscript-adapter/src/index.ts
+++ b/packages/hyperscript-adapter/src/index.ts
@@ -22,6 +22,11 @@
  * _hyperscript(english);
  */
 
-export { hyperscriptI18n, preprocess, type PluginOptions } from './plugin';
+export {
+  hyperscriptI18n,
+  preprocess,
+  resetTranslationWarnings,
+  type PluginOptions,
+} from './plugin';
 export { preprocessToEnglish, type PreprocessorConfig } from './preprocessor';
 export { resolveLanguage } from './language-resolver';

--- a/packages/hyperscript-adapter/src/plugin.ts
+++ b/packages/hyperscript-adapter/src/plugin.ts
@@ -18,6 +18,30 @@ export interface PluginOptions extends Partial<PreprocessorConfig> {
   debug?: boolean;
 }
 
+/** Languages already warned about an unchanged translation this page load.
+ *  Unchanged output is common and often legitimate (canonical-English
+ *  hyperscript under a non-en lang scope), so warning per element per
+ *  processNode was pure noise — mirror htmx-adapter's warn-once-per-lang
+ *  convention and leave per-element detail to `debug: true`. */
+const warnedUnchangedLang = new Set<string>();
+
+/** Reset the warn-once state. Mainly for tests. */
+export function resetTranslationWarnings(): void {
+  warnedUnchangedLang.clear();
+}
+
+function warnUnchangedOnce(lang: string, src: string): void {
+  if (warnedUnchangedLang.has(lang)) return;
+  warnedUnchangedLang.add(lang);
+  console.warn(
+    `[hyperscript-i18n] Translation unchanged for lang="${lang}": "${src.length > 60 ? src.slice(0, 60) + '…' : src}". ` +
+      'This is fine if the source is already canonical English; otherwise the input may not match ' +
+      'any known pattern, or the language may not be registered. Original text is passed to ' +
+      '_hyperscript as-is. Further elements in this language stay quiet — enable { debug: true } ' +
+      'for per-element detail.'
+  );
+}
+
 /**
  * Create a _hyperscript plugin that enables multilingual hyperscript.
  *
@@ -49,13 +73,10 @@ export function hyperscriptI18n(options: PluginOptions = {}) {
         if (options.debug) {
           console.log(`[hyperscript-i18n] ${lang}: "${src}" → "${english}"`);
         }
+      } else if (options.debug) {
+        console.log(`[hyperscript-i18n] ${lang}: unchanged "${src}"`);
       } else {
-        // Translation produced no change — likely a failure
-        console.warn(
-          `[hyperscript-i18n] Translation unchanged for lang="${lang}": "${src.length > 60 ? src.slice(0, 60) + '…' : src}". ` +
-            'The input may not match any known pattern, or the language may not be registered. ' +
-            'Original text will be passed to _hyperscript as-is.'
-        );
+        warnUnchangedOnce(lang, src);
       }
 
       return english;

--- a/packages/hyperscript-adapter/src/preprocessor.ts
+++ b/packages/hyperscript-adapter/src/preprocessor.ts
@@ -31,8 +31,13 @@ export interface PreprocessorConfig {
   confidenceThreshold: number | Record<string, number>;
   /** Strategy: 'semantic' (default), 'i18n', or 'auto' (semantic then i18n) */
   strategy: 'semantic' | 'i18n' | 'auto';
-  /** Whether to return original text on failure. Default: true */
-  fallbackToOriginal: boolean;
+  /**
+   * @deprecated Never implemented — `preprocessToEnglish` always returns a
+   * string, and on translation failure that string is the original source
+   * (there is nothing else it could return). The option has had no effect in
+   * any released version and is ignored; it will be removed in a future major.
+   */
+  fallbackToOriginal?: boolean;
   /** Optional i18n toEnglish function (loaded dynamically if available) */
   i18nToEnglish?: (input: string, locale: string) => string;
 }
@@ -42,7 +47,6 @@ const DEFAULT_THRESHOLD = 0.5;
 const DEFAULT_CONFIG: PreprocessorConfig = {
   confidenceThreshold: DEFAULT_THRESHOLD,
   strategy: 'semantic',
-  fallbackToOriginal: true,
 };
 
 /**
@@ -86,8 +90,9 @@ export function preprocessToEnglish(
     if (translated !== null) return stripped.prefix + translated;
   }
 
-  // Fallback: return original
-  return cfg.fallbackToOriginal ? src : src;
+  // Fallback: return original (unconditional — see fallbackToOriginal's
+  // deprecation note; the string contract leaves nothing else to return)
+  return src;
 }
 
 /**

--- a/packages/hyperscript-adapter/src/slim-preprocessor.ts
+++ b/packages/hyperscript-adapter/src/slim-preprocessor.ts
@@ -25,7 +25,6 @@ const DEFAULT_THRESHOLD = 0.5;
 const DEFAULT_CONFIG: PreprocessorConfig = {
   confidenceThreshold: DEFAULT_THRESHOLD,
   strategy: 'semantic',
-  fallbackToOriginal: true,
 };
 
 function resolveThreshold(threshold: number | Record<string, number>, lang: string): number {

--- a/packages/hyperscript-adapter/test/attribute-translator.test.ts
+++ b/packages/hyperscript-adapter/test/attribute-translator.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from 'vitest';
+import { installAttributeTranslator, type HyperscriptHost } from '../src/attribute-translator';
+
+// Same mock host surface as plugin.test.ts: addBeforeProcessHook is the
+// public seam; process() simulates Runtime#processNode running every
+// registered hook against the given root.
+function createMockHyperscript(config: { attributes?: string } = {}) {
+  const hooks: Array<(elt: Element) => void> = [];
+  return {
+    config,
+    addBeforeProcessHook: vi.fn((fn: (elt: Element) => void) => {
+      hooks.push(fn);
+    }),
+    process(root: Element) {
+      hooks.forEach(fn => fn(root));
+    },
+  };
+}
+
+function mount(html: string): HTMLElement {
+  const container = document.createElement('div');
+  container.innerHTML = html;
+  document.body.appendChild(container);
+  return container;
+}
+
+describe('installAttributeTranslator', () => {
+  it('invokes translate once per element across repeated process passes', () => {
+    const hs = createMockHyperscript();
+    const translate = vi.fn(() => 'toggle .active');
+    installAttributeTranslator(hs, translate);
+
+    const container = mount('<button _="alternar .active"></button>');
+    hs.process(container);
+    hs.process(container); // e.g. a sibling swap re-scanning a shared ancestor
+    expect(translate).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('button')!.getAttribute('_')).toBe('toggle .active');
+    container.remove();
+  });
+
+  it('mutates no DOM beyond the script-attribute rewrite (no marker attributes)', () => {
+    const hs = createMockHyperscript();
+    installAttributeTranslator(hs, () => 'toggle .active');
+
+    const container = mount('<button _="alternar .active" data-lang="es"></button>');
+    const btn = container.querySelector('button')!;
+    hs.process(container);
+
+    expect(btn.getAttribute('_')).toBe('toggle .active');
+    expect(btn.getAttributeNames().sort()).toEqual(['_', 'data-lang']);
+    container.remove();
+  });
+
+  it('adds no attributes to untouched English elements either', () => {
+    const hs = createMockHyperscript();
+    // Identity translation — the element must come out byte-identical.
+    installAttributeTranslator(hs, (src: string) => src);
+
+    const container = mount('<button _="toggle .active"></button>');
+    const btn = container.querySelector('button')!;
+    hs.process(container);
+
+    expect(btn.getAttributeNames()).toEqual(['_']);
+    expect(container.innerHTML).toBe('<button _="toggle .active"></button>');
+    container.remove();
+  });
+
+  it('rewrites <script type="text/hyperscript"> bodies without adding attributes', () => {
+    const hs = createMockHyperscript();
+    const translate = vi.fn(() => 'on click toggle .active');
+    installAttributeTranslator(hs, translate);
+
+    const container = mount('<script type="text/hyperscript">on click alternar .active</script>');
+    const script = container.querySelector('script')!;
+    hs.process(container);
+
+    expect(script.textContent).toBe('on click toggle .active');
+    expect(script.getAttributeNames()).toEqual(['type']);
+
+    // Idempotency holds for script bodies too.
+    hs.process(container);
+    expect(translate).toHaveBeenCalledTimes(1);
+    expect(script.textContent).toBe('on click toggle .active');
+    container.remove();
+  });
+
+  it('re-processes NEW element instances after a serialize→reparse round-trip', () => {
+    const hs = createMockHyperscript();
+    const translate = vi.fn((src: string) => (src === 'alternar .active' ? 'toggle .active' : src));
+    installAttributeTranslator(hs, translate);
+
+    const container = mount('<button _="alternar .active"></button>');
+    hs.process(container);
+    expect(translate).toHaveBeenCalledTimes(1);
+
+    // innerHTML round-trip discards the original element, so processed-set
+    // membership is lost by design. The NEW element is re-processed — its
+    // text is already English, so translation is an identity no-op.
+    container.innerHTML = container.innerHTML;
+    hs.process(container);
+    expect(translate).toHaveBeenCalledTimes(2);
+    expect(translate).toHaveBeenLastCalledWith('toggle .active', expect.anything());
+    expect(container.querySelector('button')!.getAttribute('_')).toBe('toggle .active');
+    container.remove();
+  });
+
+  it('honors custom config.attributes names', () => {
+    const hs = createMockHyperscript({ attributes: 'data-script' });
+    installAttributeTranslator(hs, () => 'toggle .active');
+
+    const container = mount('<button data-script="alternar .active"></button>');
+    hs.process(container);
+    expect(container.querySelector('button')!.getAttribute('data-script')).toBe('toggle .active');
+    container.remove();
+  });
+
+  it('warns and installs nothing on hosts without addBeforeProcessHook', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const host: HyperscriptHost = {}; // e.g. _hyperscript ≤ 0.9.14
+    expect(() => installAttributeTranslator(host, src => src)).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('addBeforeProcessHook'));
+    warnSpy.mockRestore();
+  });
+});

--- a/packages/hyperscript-adapter/test/plugin.test.ts
+++ b/packages/hyperscript-adapter/test/plugin.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect, vi } from 'vitest';
-import { hyperscriptI18n, preprocess } from '../src/plugin';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { hyperscriptI18n, preprocess, resetTranslationWarnings } from '../src/plugin';
+
+beforeEach(() => resetTranslationWarnings());
 
 // Mocks the _hyperscript.org host surface this plugin actually depends on:
 // addBeforeProcessHook (public), not internals.runtime.getScript — that's a
@@ -129,6 +131,100 @@ describe('hyperscriptI18n plugin', () => {
     hs.process(document.body);
     expect(elt.getAttribute('_')).toBe('toggle .active');
     elt.remove();
+  });
+
+  it('leaves no marker attribute on the DOM — the element reads as authored', () => {
+    const hs = createMockHyperscript();
+    hyperscriptI18n()(hs);
+
+    const elt = document.createElement('button');
+    elt.setAttribute('_', 'alternar .active');
+    elt.setAttribute('data-lang', 'es');
+    document.body.appendChild(elt);
+
+    hs.process(document.body);
+    expect(elt.getAttribute('_')).toBe('toggle .active');
+    expect(elt.getAttributeNames().sort()).toEqual(['_', 'data-lang']);
+    elt.remove();
+  });
+
+  it('stays correct after a serialize→reparse round-trip loses processed-set membership', () => {
+    const hs = createMockHyperscript();
+    hyperscriptI18n()(hs);
+
+    const container = document.createElement('div');
+    container.innerHTML = '<button _="alternar .active" data-lang="es"></button>';
+    document.body.appendChild(container);
+
+    hs.process(container);
+    expect(container.querySelector('button')!.getAttribute('_')).toBe('toggle .active');
+
+    // Serialize and reparse (as an hx-boost-style morph or template clone
+    // would): the WeakSet no longer knows the new element. Re-processing it
+    // feeds already-English text back through translation under lang="es" —
+    // which must be an identity no-op, not a mangle.
+    container.innerHTML = container.innerHTML;
+    hs.process(container);
+    expect(container.querySelector('button')!.getAttribute('_')).toBe('toggle .active');
+    container.remove();
+  });
+});
+
+describe('unchanged-translation warnings', () => {
+  // Garbled inputs at threshold 1.0 reliably produce unchanged output
+  // (same technique as preprocessor.test.ts's confidence-fallback case).
+  const OPTS = { confidenceThreshold: 1.0 };
+
+  function addGarbage(lang: string, src: string): Element {
+    const elt = document.createElement('button');
+    elt.setAttribute('_', src);
+    elt.setAttribute('data-lang', lang);
+    document.body.appendChild(elt);
+    return elt;
+  }
+
+  it('warns once per language, not per element', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const hs = createMockHyperscript();
+    hyperscriptI18n(OPTS)(hs);
+
+    const a = addGarbage('es', 'xyz abc 123');
+    const b = addGarbage('es', 'qrs tuv 789');
+    hs.process(document.body);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('lang="es"'));
+
+    // A different language still gets its own (single) warning.
+    const c = addGarbage('ja', 'xyz abc 123');
+    hs.process(document.body);
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenLastCalledWith(expect.stringContaining('lang="ja"'));
+
+    warnSpy.mockRestore();
+    a.remove();
+    b.remove();
+    c.remove();
+  });
+
+  it('debug mode logs per element and never warns', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const hs = createMockHyperscript();
+    hyperscriptI18n({ ...OPTS, debug: true })(hs);
+
+    const a = addGarbage('es', 'xyz abc 123');
+    const b = addGarbage('es', 'qrs tuv 789');
+    hs.process(document.body);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    const unchangedLogs = logSpy.mock.calls.filter(c => String(c[0]).includes('unchanged'));
+    expect(unchangedLogs).toHaveLength(2);
+
+    warnSpy.mockRestore();
+    logSpy.mockRestore();
+    a.remove();
+    b.remove();
   });
 });
 

--- a/packages/hyperscript-adapter/test/preprocessor.test.ts
+++ b/packages/hyperscript-adapter/test/preprocessor.test.ts
@@ -150,6 +150,17 @@ describe('preprocessToEnglish', () => {
       });
       expect(result).toBe('xyz abc 123');
     });
+
+    it('falls back to the original even with fallbackToOriginal: false (deprecated, inert)', () => {
+      // The option never did anything — the string contract leaves nothing
+      // else to return on failure. Pin that so removing the dead branch is
+      // provably behavior-preserving, and so the deprecation stays honest.
+      const result = preprocessToEnglish('xyz abc 123', 'es', {
+        confidenceThreshold: 1.0,
+        fallbackToOriginal: false,
+      });
+      expect(result).toBe('xyz abc 123');
+    });
   });
 
   describe('all-languages smoke test', () => {


### PR DESCRIPTION
Step 2 of the hyperscript-adapter review's sequenced plan (F3 + F6 + F7 — small behavior fixes, each with tests), landing against the e2e net #895 established.

## F6: warning noise → warn once per language

`plugin.ts` warned "Translation unchanged … likely a failure" **per element per processNode pass** — but unchanged output is often legitimate (canonical-English hyperscript under a non-en `lang` scope is a common authoring pattern). Now:

- warns **once per language per page load**, mirroring htmx-adapter's `warnMissingLangOnce` convention (module-level `Set`, exported `resetTranslationWarnings()` for tests)
- the message now says the canonical-English case is fine, and points at `{ debug: true }`
- debug mode logs per-element detail (including unchanged inputs) and never warns

Only `plugin.ts` ever had the warning; the slim/lite plugin variants never warned and are untouched.

## F7: `TRANSLATED_MARKER` DOM attribute → WeakSet

Every matched element — including untouched English ones — got `data-hyperscript-i18n-translated` stamped on it. A module-level `WeakSet<Element>` provides the same re-process idempotency (sibling swap re-scanning a shared ancestor) with **zero DOM mutation**: devtools and serialization show exactly what the author wrote, the same devtools-faithfulness value as #894's preserve mode.

The serialize→reparse edge the review flagged is tested twice: at the seam (new element instances after an `innerHTML` round-trip ARE re-processed) and behaviorally (the attribute stays correct English, because re-translating already-English text is confidence-gated into an identity no-op).

## F3: `fallbackToOriginal` deprecated (it was dead code)

`preprocessor.ts` had `return cfg.fallbackToOriginal ? src : src;` — both branches identical since the option shipped, and the slim path never consulted it. The public string contract leaves nothing else to return on failure, so implementing `false` is not meaningful. Deprecated in the type (optional + `@deprecated` explaining it never had an effect), removed from both `DEFAULT_CONFIG`s, dead ternary simplified. A new test pins the option as inert so the deprecation claim stays honest. No runtime behavior change; type-compatible for existing consumers of the published package.

## Verification

- vitest: **221/221** (was 209; +12 — new `attribute-translator.test.ts` covering the hook seam directly, plus warn-once/serialize-reparse/no-marker pins in `plugin.test.ts` and the F3 pin in `preprocessor.test.ts`)
- **Mutation probe** (per the repo's redden-the-behavioral-row rule): with `main`'s marker-based `attribute-translator.ts` swapped in, exactly the five new marker-related pins fail; restored, 221/221
- e2e: **31/31** against the rebuilt bundle
- typecheck clean; package CLAUDE.md updated (new design decisions + test count)

Remaining from the review, in sequence: F2 (lang cascade), F4/F5 (preprocessor dedupe + measurement-gated split reorder), F8 (optional parse-validity gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)