### PR TITLE
refactor(hyperscript-adapter): one preprocessor skeleton, two parse/render hooks, parity-pinned

### DIFF
--- a/packages/hyperscript-adapter/CLAUDE.md
+++ b/packages/hyperscript-adapter/CLAUDE.md
@@ -17,8 +17,9 @@ src/
 ├── browser-lite.ts       # Lite browser entry — expects external semantic global
 ├── plugin.ts             # _hyperscript.use() plugin factory + standalone preprocess()
 ├── slim-plugin.ts        # Slim plugin factory (imports from semantic/core)
-├── preprocessor.ts       # Semantic translation with confidence gating (full)
-├── slim-preprocessor.ts  # Slim preprocessor (imports from semantic/core + custom renderer)
+├── preprocessor-core.ts  # Shared skeleton: strategies, then-splitting, prefix-stripping
+├── preprocessor.ts       # Full path: parseSemantic + render('en') + translate() rescue
+├── slim-preprocessor.ts  # Slim path: parseWithConfidence + custom renderer (semantic/core)
 ├── hyperscript-renderer.ts  # Custom English renderer — no English lang data needed
 ├── attribute-translator.ts  # The runtime seam: addBeforeProcessHook installer
 ├── language-resolver.ts  # Lang cascade: data-* overrides → closest [lang] → document (matches htmx-adapter's langOf)
@@ -38,6 +39,10 @@ test/
 ├── language-resolver.test.ts  # DOM attribute resolution
 ├── plugin.test.ts             # Plugin registration, warn-once, serialize→reparse behavior
 ├── attribute-translator.test.ts  # Hook seam: WeakSet idempotency, zero DOM mutation
+├── parity-harness.ts          # Shared parity corpus (no preprocessor imports — see file doc)
+├── preprocessor-parity.full.test.ts  # Full path vs committed snapshot
+├── preprocessor-parity.slim.test.ts  # Slim path vs committed snapshot (own module graph)
+├── fixtures/preprocessor-parity.json # Snapshot: both paths' outputs + divergence set
 ├── derive-syntax.test.ts      # Drift gate: generated syntax-table vs schemas
 └── browser/                   # Playwright e2e against the REAL _hyperscript runtime
     ├── adapter.spec.ts        # Localized toggles/add/put/remove across 8 languages + inheritance
@@ -51,7 +56,7 @@ demo/
 
 ```bash
 npm run typecheck          # TypeScript validation
-npm run test:run           # Vitest (221 tests, jsdom environment)
+npm run test:run           # Vitest (316 tests, jsdom environment)
 npm run test:browser       # Playwright e2e vs real vendored _hyperscript (build dist first)
 npm run build              # ESM + CJS + browser IIFEs (prebuild regenerates syntax-table)
 npm run generate:syntax    # Regenerate src/generated/syntax-table.ts after schema changes
@@ -65,7 +70,7 @@ The e2e suite serves the repo root on port **3010** (core's Playwright uses
 
 - **Preprocessor, not AST mapping**: \_hyperscript AST nodes are closure objects tightly coupled to the parser — reproducing them from semantic data would mean reimplementing every command parser
 - **Custom English renderer**: Per-language bundles use `hyperscript-renderer.ts` to render SemanticNodes to English \_hyperscript strings without needing English language data (tokenizer, profile, patterns), saving ~26 KB per bundle
-- **Two preprocessor paths**: `preprocessor.ts` (full, imports `@lokascript/semantic`) for the all-language bundle; `slim-preprocessor.ts` (imports `@lokascript/semantic/core` + custom renderer) for per-language bundles. Known divergence risk: the two paths render through different renderers and share no parity test yet
+- **Two preprocessor paths, one skeleton**: the strategy/split/strip logic lives once in `preprocessor-core.ts`; `preprocessor.ts` (full, `@lokascript/semantic`) and `slim-preprocessor.ts` (`…/core` + custom renderer) inject only their parse/render hooks. The paths still legitimately differ — full has the rich handcrafted-pattern builder and a `translate()` rescue; slim's schema-only generator currently loses 5 corpus rows (zh `切换` toggle, `set` in es/zh) — and that divergence set is COMMITTED DATA in the parity ratchet (`test/preprocessor-parity.*.test.ts` + `fixtures/preprocessor-parity.json`, regenerated via `scripts/generate-parity-fixture.ts`). Two test FILES on purpose: the paths wire different pattern generators into the registry, and under vitest's shared-src aliases one file = one module graph = one registry, so importing both chains together lets whichever wires last silently reconfigure the other (measured — the full path lost exactly the handcrafted rows)
 - **Confidence gating**: semantic analysis below threshold falls through to original text, avoiding bad translations. This also makes re-processing safe: already-translated English fed back through translation is an identity no-op
 - **WeakSet idempotency, zero DOM mutation**: the attribute translator tracks processed elements in a module-level `WeakSet` instead of stamping a marker attribute — devtools/serialization show exactly what the author wrote. A serialize→reparse round-trip produces new elements that are re-processed, which the confidence gate makes harmless (tested)
 - **Warn once per language**: an unchanged translation is often legitimate (canonical-English hyperscript under a non-en lang scope), so the full plugin warns once per language per page load (mirroring htmx-adapter's `warnMissingLangOnce`); `{ debug: true }` gives per-element detail. `resetTranslationWarnings()` resets the once-state (mainly for tests)

--- a/packages/hyperscript-adapter/scripts/generate-parity-fixture.ts
+++ b/packages/hyperscript-adapter/scripts/generate-parity-fixture.ts
@@ -1,0 +1,69 @@
+/**
+ * Generate the full-vs-slim preprocessor parity fixture.
+ *
+ * Runs the shared corpus (test/parity-harness.ts) through both
+ * preprocessor paths and snapshots each path's output byte-exactly into
+ * test/fixtures/preprocessor-parity.json. The two parity test files diff
+ * against this snapshot on every vitest run — see
+ * test/preprocessor-parity.full.test.ts for the full rationale.
+ *
+ * This script runs under tsx against the workspace DIST artifacts, where
+ * the full package (`@lokascript/semantic`) and the slim chain
+ * (`@lokascript/semantic/core` + `/languages/*`) are separate bundles with
+ * separate registries — the same isolation the shipped browser bundles
+ * have, so wiring the slim pattern generator below cannot leak into the
+ * full path's rich builder. (The vitest tests get the same isolation from
+ * per-file module graphs instead.)
+ *
+ * Regenerate ONLY for an intentional behavior change, from a tree whose
+ * semantic dist is fresh (`npm run check:fresh` at the repo root first):
+ *
+ *   npx tsx scripts/generate-parity-fixture.ts
+ */
+
+import { writeFileSync, mkdirSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import {
+  setPatternGenerator,
+  generatePatternsForLanguage,
+  type LanguageProfile,
+} from '@lokascript/semantic/core';
+
+// Side-effect language registrations for the slim chain — same as the
+// per-language bundle entries. Keep in sync with SLIM_LANGS.
+import '@lokascript/semantic/languages/es';
+import '@lokascript/semantic/languages/ja';
+import '@lokascript/semantic/languages/ko';
+import '@lokascript/semantic/languages/zh';
+import '@lokascript/semantic/languages/fr';
+import '@lokascript/semantic/languages/ar';
+
+import { preprocessToEnglish as fullPreprocess } from '../src/preprocessor';
+import { preprocessToEnglish as slimPreprocess } from '../src/slim-preprocessor';
+import { PARITY_CORPUS } from '../test/parity-harness';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Same wiring as src/bundles/shared.ts.
+setPatternGenerator((profile: LanguageProfile) => generatePatternsForLanguage(profile));
+
+const rows = PARITY_CORPUS.map(({ lang, input, config }) => ({
+  lang,
+  input,
+  ...(config ? { config } : {}),
+  full: fullPreprocess(input, lang, config ?? {}),
+  slim: slimPreprocess(input, lang, config ?? {}),
+}));
+
+const divergent = rows.filter(r => r.full !== r.slim).length;
+const outDir = path.join(__dirname, '..', 'test', 'fixtures');
+mkdirSync(outDir, { recursive: true });
+const outFile = path.join(outDir, 'preprocessor-parity.json');
+writeFileSync(outFile, JSON.stringify(rows, null, 2) + '\n');
+
+console.log(
+  `Wrote ${rows.length} rows to ${path.relative(process.cwd(), outFile)} ` +
+    `(${divergent} full-vs-slim divergences)`
+);

--- a/packages/hyperscript-adapter/src/preprocessor-core.ts
+++ b/packages/hyperscript-adapter/src/preprocessor-core.ts
@@ -1,0 +1,269 @@
+/**
+ * Preprocessor core — the shared skeleton of the full and slim
+ * preprocessors.
+ *
+ * Everything that is NOT genuinely different between the two paths lives
+ * here exactly once: config defaults/threshold resolution, strategy
+ * ordering (semantic → optional i18n), compound splitting on localized
+ * `then` keywords and newlines, event-prefix stripping, and the
+ * return-original fallback. The two real differences stay with each path,
+ * injected as hooks:
+ *
+ *   - HOW one statement is parsed and rendered to English
+ *     (`translateSingle`): the full path uses semantic's parseSemantic +
+ *     render + a translate() rescue for confident-but-nodeless parses;
+ *     the slim path uses parseWithConfidence + the custom
+ *     hyperscript-renderer (no English language data).
+ *   - WHERE registry/profile lookups come from (`isLanguageRegistered`,
+ *     `tryGetProfile`): `@lokascript/semantic` vs `…/core` — under tsup's
+ *     split dist these are separate registry instances, so each path must
+ *     bring its own.
+ *
+ * Behavior is pinned by the parity ratchet
+ * (test/preprocessor-parity.*.test.ts + the committed fixture): both paths
+ * are byte-identical to their pre-extraction outputs over the corpus.
+ */
+
+export interface PreprocessorConfig {
+  /**
+   * Minimum confidence threshold for semantic parsing (0-1). Default: 0.5.
+   * Can be a single number (applies to all languages) or a per-language map.
+   * Per-language thresholds are useful because SOV languages (ja, ko, tr) produce
+   * inherently lower confidence scores than SVO languages (es, fr, de).
+   *
+   * @example
+   * // Single threshold
+   * { confidenceThreshold: 0.5 }
+   *
+   * @example
+   * // Per-language thresholds
+   * { confidenceThreshold: { es: 0.7, ja: 0.1, ko: 0.05, '*': 0.5 } }
+   */
+  confidenceThreshold: number | Record<string, number>;
+  /** Strategy: 'semantic' (default), 'i18n', or 'auto' (semantic then i18n) */
+  strategy: 'semantic' | 'i18n' | 'auto';
+  /**
+   * @deprecated Never implemented — `preprocessToEnglish` always returns a
+   * string, and on translation failure that string is the original source
+   * (there is nothing else it could return). The option has had no effect in
+   * any released version and is ignored; it will be removed in a future major.
+   */
+  fallbackToOriginal?: boolean;
+  /** Optional i18n toEnglish function (loaded dynamically if available) */
+  i18nToEnglish?: (input: string, locale: string) => string;
+}
+
+/** Minimal profile shape the skeleton needs (then-keyword lookup). */
+export interface ThenProfile {
+  keywords?: {
+    then?: { primary?: string; alternatives?: string[] };
+  };
+}
+
+/** The per-path seam — see module doc. */
+export interface PreprocessorHooks {
+  isLanguageRegistered(lang: string): boolean;
+  tryGetProfile(lang: string): ThenProfile | null | undefined;
+  /**
+   * Parse ONE statement in `lang` and render it to English. Return null
+   * when it cannot be translated (below-threshold confidence, no node, …);
+   * the skeleton then tries the remaining strategies / falls back.
+   */
+  translateSingle(src: string, lang: string, threshold: number): string | null;
+}
+
+const DEFAULT_THRESHOLD = 0.5;
+
+const DEFAULT_CONFIG: PreprocessorConfig = {
+  confidenceThreshold: DEFAULT_THRESHOLD,
+  strategy: 'semantic',
+};
+
+/**
+ * Resolve the confidence threshold for a specific language.
+ * Supports both a single number and a per-language map with '*' as default.
+ */
+function resolveThreshold(threshold: number | Record<string, number>, lang: string): number {
+  if (typeof threshold === 'number') return threshold;
+  return threshold[lang] ?? threshold['*'] ?? DEFAULT_THRESHOLD;
+}
+
+/**
+ * Match _hyperscript event handler prefix: "on [every] <event>[filter][.modifiers] "
+ *
+ * Examples:
+ *   "on click toggle .active"            → prefix: "on click ", commands: "toggle .active"
+ *   "on every click toggle .active"      → prefix: "on every click ", commands: "toggle .active"
+ *   "on click.debounce(300) toggle .x"   → prefix: "on click.debounce(300) ", commands: "toggle .x"
+ *   "on keyup[key=='Enter'] set x to 1"  → prefix: "on keyup[key=='Enter'] ", commands: "set x to 1"
+ *   "on click from body toggle .active"  → prefix: "on click from body ", commands: "toggle .active"
+ */
+const EVENT_PREFIX_RE =
+  /^(on\s+(?:every\s+)?[\w-]+(?:\[.*?\])?(?:\.[\w-]+(?:\([^)]*\))?)*(?:\s+from\s+\S+)?(?:\s+queue\s+\w+)?\s+)/;
+
+function stripEventPrefix(src: string): { prefix: string; commands: string } | null {
+  const match = src.match(EVENT_PREFIX_RE);
+  if (!match) return null;
+  const prefix = match[1];
+  const commands = src.slice(prefix.length);
+  if (!commands) return null;
+  return { prefix, commands };
+}
+
+/**
+ * Build a `preprocessToEnglish` function from the per-path hooks.
+ *
+ * Handles _hyperscript feature prefixes (e.g. "on click", "on every keyup")
+ * by stripping them, translating only the command portion, then reassembling.
+ */
+export function createPreprocessToEnglish(
+  hooks: PreprocessorHooks
+): (src: string, lang: string, config?: Partial<PreprocessorConfig>) => string {
+  /**
+   * Get all "then" keyword forms for a language (primary + alternatives).
+   * Falls back to English "then" if profile is unavailable.
+   */
+  function getThenKeywords(lang: string): string[] {
+    const keywords = ['then']; // Always include English
+    const profile = hooks.tryGetProfile(lang);
+    if (profile?.keywords?.then) {
+      const kw = profile.keywords.then;
+      if (kw.primary && kw.primary !== 'then') keywords.push(kw.primary);
+      if (kw.alternatives) {
+        for (const alt of kw.alternatives) {
+          if (!keywords.includes(alt)) keywords.push(alt);
+        }
+      }
+    }
+    return keywords;
+  }
+
+  /**
+   * Split a hyperscript source string into individual statements.
+   * Splits on language-specific "then" keywords and newlines.
+   */
+  function splitStatements(src: string, lang: string): string[] {
+    const thenWords = getThenKeywords(lang);
+    // Escape regex special chars and build pattern
+    const escaped = thenWords.map(w => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+    const pattern = new RegExp(`\\s+(?:${escaped.join('|')})\\s+`, 'i');
+
+    // Split on newlines first
+    const lines = src
+      .split('\n')
+      .map(l => l.trim())
+      .filter(l => l.length > 0);
+    const result: string[] = [];
+    for (const line of lines) {
+      const parts = line.split(pattern);
+      result.push(...parts);
+    }
+    return result;
+  }
+
+  /**
+   * Try semantic translation: parse in source language, render to English.
+   * Returns null if confidence is below threshold.
+   */
+  function trySemanticTranslation(src: string, lang: string, threshold: number): string | null {
+    try {
+      // Handle compound statements (split on "then" boundaries and newlines)
+      const statements = splitStatements(src, lang);
+      if (statements.length > 1) {
+        return translateCompound(statements, lang, threshold);
+      }
+
+      // Check if the semantic parser can handle this
+      if (!hooks.isLanguageRegistered(lang)) return null;
+
+      return hooks.translateSingle(src, lang, threshold);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Translate compound statements individually and rejoin with " then ".
+   */
+  function translateCompound(statements: string[], lang: string, threshold: number): string | null {
+    const translated: string[] = [];
+    for (const stmt of statements) {
+      const result = trySemanticTranslation(stmt.trim(), lang, threshold);
+      if (result === null) return null; // If any part fails, fail the whole compound
+      translated.push(result);
+    }
+    return translated.join(' then ');
+  }
+
+  /**
+   * Try i18n grammar transformation to English.
+   * Returns null if the result is identical to input (no translation happened).
+   */
+  function tryI18nTranslation(
+    src: string,
+    lang: string,
+    toEnglish: (input: string, locale: string) => string
+  ): string | null {
+    try {
+      const result = toEnglish(src, lang);
+      return result !== src ? result : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Try all configured translation strategies on the input.
+   * Returns null if none succeed.
+   */
+  function tryTranslateWithStrategies(
+    src: string,
+    lang: string,
+    cfg: PreprocessorConfig
+  ): string | null {
+    // Strategy: semantic-only
+    if (cfg.strategy === 'semantic' || cfg.strategy === 'auto') {
+      const threshold = resolveThreshold(cfg.confidenceThreshold, lang);
+      const result = trySemanticTranslation(src, lang, threshold);
+      if (result !== null) return result;
+    }
+
+    // Strategy: i18n fallback (auto mode or i18n-only)
+    if ((cfg.strategy === 'auto' || cfg.strategy === 'i18n') && cfg.i18nToEnglish) {
+      const result = tryI18nTranslation(src, lang, cfg.i18nToEnglish);
+      if (result !== null) return result;
+    }
+
+    return null;
+  }
+
+  return function preprocessToEnglish(
+    src: string,
+    lang: string,
+    config: Partial<PreprocessorConfig> = {}
+  ): string {
+    // English→English is identity; skip semantic parsing which may mangle
+    // the input. (Historically full-path only — the slim path gained it in
+    // the shared-skeleton extraction, deliberately: it is a mangle guard.)
+    if (lang === 'en') return src;
+
+    const cfg = { ...DEFAULT_CONFIG, ...config };
+
+    // Try translating the full string first
+    const fullResult = tryTranslateWithStrategies(src, lang, cfg);
+    if (fullResult !== null) return fullResult;
+
+    // If full translation failed, try stripping event/feature prefix.
+    // _hyperscript attributes often contain "on <event> <commands>" — the semantic
+    // parser only understands command syntax, not event declarations.
+    const stripped = stripEventPrefix(src);
+    if (stripped) {
+      const translated = tryTranslateWithStrategies(stripped.commands, lang, cfg);
+      if (translated !== null) return stripped.prefix + translated;
+    }
+
+    // Fallback: return original (unconditional — see fallbackToOriginal's
+    // deprecation note; the string contract leaves nothing else to return)
+    return src;
+  };
+}

--- a/packages/hyperscript-adapter/src/preprocessor.ts
+++ b/packages/hyperscript-adapter/src/preprocessor.ts
@@ -1,8 +1,13 @@
 /**
- * Preprocessor
+ * Preprocessor (full path)
  *
  * Translates non-English hyperscript to English using the semantic parser
  * (with optional i18n fallback), so the original _hyperscript can parse it.
+ *
+ * The strategy/split/strip skeleton lives in preprocessor-core.ts, shared
+ * with the slim path — only HOW one statement is parsed and rendered
+ * differs here: semantic's parseSemantic + render('en'), plus a
+ * translate() rescue when the parse is confident but yields no node.
  */
 
 import {
@@ -13,150 +18,20 @@ import {
   tryGetProfile,
 } from '@lokascript/semantic';
 
-export interface PreprocessorConfig {
-  /**
-   * Minimum confidence threshold for semantic parsing (0-1). Default: 0.5.
-   * Can be a single number (applies to all languages) or a per-language map.
-   * Per-language thresholds are useful because SOV languages (ja, ko, tr) produce
-   * inherently lower confidence scores than SVO languages (es, fr, de).
-   *
-   * @example
-   * // Single threshold
-   * { confidenceThreshold: 0.5 }
-   *
-   * @example
-   * // Per-language thresholds
-   * { confidenceThreshold: { es: 0.7, ja: 0.1, ko: 0.05, '*': 0.5 } }
-   */
-  confidenceThreshold: number | Record<string, number>;
-  /** Strategy: 'semantic' (default), 'i18n', or 'auto' (semantic then i18n) */
-  strategy: 'semantic' | 'i18n' | 'auto';
-  /**
-   * @deprecated Never implemented — `preprocessToEnglish` always returns a
-   * string, and on translation failure that string is the original source
-   * (there is nothing else it could return). The option has had no effect in
-   * any released version and is ignored; it will be removed in a future major.
-   */
-  fallbackToOriginal?: boolean;
-  /** Optional i18n toEnglish function (loaded dynamically if available) */
-  i18nToEnglish?: (input: string, locale: string) => string;
-}
+import { createPreprocessToEnglish, type PreprocessorConfig } from './preprocessor-core';
 
-const DEFAULT_THRESHOLD = 0.5;
-
-const DEFAULT_CONFIG: PreprocessorConfig = {
-  confidenceThreshold: DEFAULT_THRESHOLD,
-  strategy: 'semantic',
-};
-
-/**
- * Resolve the confidence threshold for a specific language.
- * Supports both a single number and a per-language map with '*' as default.
- */
-function resolveThreshold(threshold: number | Record<string, number>, lang: string): number {
-  if (typeof threshold === 'number') return threshold;
-  return threshold[lang] ?? threshold['*'] ?? DEFAULT_THRESHOLD;
-}
+export type { PreprocessorConfig };
 
 /**
  * Preprocess non-English hyperscript into English.
  *
  * Uses the semantic parser to parse the input in the source language,
  * then renders back to English. Falls through to i18n if configured.
- *
- * Handles _hyperscript feature prefixes (e.g. "on click", "on every keyup")
- * by stripping them, translating only the command portion, then reassembling.
  */
-export function preprocessToEnglish(
-  src: string,
-  lang: string,
-  config: Partial<PreprocessorConfig> = {}
-): string {
-  // English→English is identity; skip semantic parsing which may mangle the input
-  if (lang === 'en') return src;
-
-  const cfg = { ...DEFAULT_CONFIG, ...config };
-
-  // Try translating the full string first
-  const fullResult = tryTranslateWithStrategies(src, lang, cfg);
-  if (fullResult !== null) return fullResult;
-
-  // If full translation failed, try stripping event/feature prefix.
-  // _hyperscript attributes often contain "on <event> <commands>" — the semantic
-  // parser only understands command syntax, not event declarations.
-  const stripped = stripEventPrefix(src);
-  if (stripped) {
-    const translated = tryTranslateWithStrategies(stripped.commands, lang, cfg);
-    if (translated !== null) return stripped.prefix + translated;
-  }
-
-  // Fallback: return original (unconditional — see fallbackToOriginal's
-  // deprecation note; the string contract leaves nothing else to return)
-  return src;
-}
-
-/**
- * Try all configured translation strategies on the input.
- * Returns null if none succeed.
- */
-function tryTranslateWithStrategies(
-  src: string,
-  lang: string,
-  cfg: PreprocessorConfig
-): string | null {
-  // Strategy: semantic-only
-  if (cfg.strategy === 'semantic' || cfg.strategy === 'auto') {
-    const threshold = resolveThreshold(cfg.confidenceThreshold, lang);
-    const result = trySemanticTranslation(src, lang, threshold);
-    if (result !== null) return result;
-  }
-
-  // Strategy: i18n fallback (auto mode or i18n-only)
-  if ((cfg.strategy === 'auto' || cfg.strategy === 'i18n') && cfg.i18nToEnglish) {
-    const result = tryI18nTranslation(src, lang, cfg.i18nToEnglish);
-    if (result !== null) return result;
-  }
-
-  return null;
-}
-
-/**
- * Match _hyperscript event handler prefix: "on [every] <event>[filter][.modifiers] "
- *
- * Examples:
- *   "on click toggle .active"            → prefix: "on click ", commands: "toggle .active"
- *   "on every click toggle .active"      → prefix: "on every click ", commands: "toggle .active"
- *   "on click.debounce(300) toggle .x"   → prefix: "on click.debounce(300) ", commands: "toggle .x"
- *   "on keyup[key=='Enter'] set x to 1"  → prefix: "on keyup[key=='Enter'] ", commands: "set x to 1"
- *   "on click from body toggle .active"  → prefix: "on click from body ", commands: "toggle .active"
- */
-const EVENT_PREFIX_RE =
-  /^(on\s+(?:every\s+)?[\w-]+(?:\[.*?\])?(?:\.[\w-]+(?:\([^)]*\))?)*(?:\s+from\s+\S+)?(?:\s+queue\s+\w+)?\s+)/;
-
-function stripEventPrefix(src: string): { prefix: string; commands: string } | null {
-  const match = src.match(EVENT_PREFIX_RE);
-  if (!match) return null;
-  const prefix = match[1];
-  const commands = src.slice(prefix.length);
-  if (!commands) return null;
-  return { prefix, commands };
-}
-
-/**
- * Try semantic translation: parse in source language, render to English.
- * Returns null if confidence is below threshold.
- */
-function trySemanticTranslation(src: string, lang: string, threshold: number): string | null {
-  try {
-    // Handle compound statements (split on "then" boundaries and newlines)
-    const statements = splitStatements(src, lang);
-    if (statements.length > 1) {
-      return translateCompound(statements, lang, threshold);
-    }
-
-    // Check if the semantic parser can handle this
-    if (!isLanguageRegistered(lang)) return null;
-
+export const preprocessToEnglish = createPreprocessToEnglish({
+  isLanguageRegistered,
+  tryGetProfile,
+  translateSingle(src, lang, threshold) {
     const result = parseSemantic(src, lang);
     if (result.confidence < threshold || !result.node) {
       // If we got SOME confidence but no node, fall back to translate()
@@ -168,79 +43,5 @@ function trySemanticTranslation(src: string, lang: string, threshold: number): s
 
     // Render the semantic node to English
     return render(result.node, 'en');
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Try i18n grammar transformation to English.
- * Returns null if the result is identical to input (no translation happened).
- */
-function tryI18nTranslation(
-  src: string,
-  lang: string,
-  toEnglish: (input: string, locale: string) => string
-): string | null {
-  try {
-    const result = toEnglish(src, lang);
-    return result !== src ? result : null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Get all "then" keyword forms for a language (primary + alternatives).
- * Falls back to English "then" if profile is unavailable.
- */
-function getThenKeywords(lang: string): string[] {
-  const keywords = ['then']; // Always include English
-  const profile = tryGetProfile(lang);
-  if (profile?.keywords?.then) {
-    const kw = profile.keywords.then;
-    if (kw.primary && kw.primary !== 'then') keywords.push(kw.primary);
-    if (kw.alternatives) {
-      for (const alt of kw.alternatives) {
-        if (!keywords.includes(alt)) keywords.push(alt);
-      }
-    }
-  }
-  return keywords;
-}
-
-/**
- * Split a hyperscript source string into individual statements.
- * Splits on language-specific "then" keywords and newlines.
- */
-function splitStatements(src: string, lang: string): string[] {
-  const thenWords = getThenKeywords(lang);
-  // Escape regex special chars and build pattern
-  const escaped = thenWords.map(w => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
-  const pattern = new RegExp(`\\s+(?:${escaped.join('|')})\\s+`, 'i');
-
-  // Split on newlines first
-  const lines = src
-    .split('\n')
-    .map(l => l.trim())
-    .filter(l => l.length > 0);
-  const result: string[] = [];
-  for (const line of lines) {
-    const parts = line.split(pattern);
-    result.push(...parts);
-  }
-  return result;
-}
-
-/**
- * Translate compound statements individually and rejoin with " then ".
- */
-function translateCompound(statements: string[], lang: string, threshold: number): string | null {
-  const translated: string[] = [];
-  for (const stmt of statements) {
-    const result = trySemanticTranslation(stmt.trim(), lang, threshold);
-    if (result === null) return null; // If any part fails, fail the whole compound
-    translated.push(result);
-  }
-  return translated.join(' then ');
-}
+  },
+});

--- a/packages/hyperscript-adapter/src/slim-preprocessor.ts
+++ b/packages/hyperscript-adapter/src/slim-preprocessor.ts
@@ -1,12 +1,14 @@
 /**
  * Slim Preprocessor
  *
- * Same logic as preprocessor.ts but imports from @lokascript/semantic/core
- * and uses a custom hyperscript renderer instead of the semantic package's
- * render(). This avoids importing English language data (tokenizer, patterns,
- * profile), saving ~35 KB per per-language bundle.
+ * Same skeleton as preprocessor.ts (shared via preprocessor-core.ts) but
+ * imports from @lokascript/semantic/core and renders through the custom
+ * hyperscript renderer instead of the semantic package's render(). This
+ * avoids importing English language data (tokenizer, patterns, profile),
+ * saving ~35 KB per per-language bundle.
  *
- * Used by per-language browser bundles for tree-shaking.
+ * Used by per-language browser bundles for tree-shaking. Must never
+ * import from '@lokascript/semantic' (the full package) at runtime.
  */
 
 // Import from /core — does NOT trigger all-language registration.
@@ -18,154 +20,20 @@ import {
 } from '@lokascript/semantic/core';
 
 import { renderToHyperscript } from './hyperscript-renderer';
-import type { PreprocessorConfig } from './preprocessor';
+import { createPreprocessToEnglish, type PreprocessorConfig } from './preprocessor-core';
 
-const DEFAULT_THRESHOLD = 0.5;
-
-const DEFAULT_CONFIG: PreprocessorConfig = {
-  confidenceThreshold: DEFAULT_THRESHOLD,
-  strategy: 'semantic',
-};
-
-function resolveThreshold(threshold: number | Record<string, number>, lang: string): number {
-  if (typeof threshold === 'number') return threshold;
-  return threshold[lang] ?? threshold['*'] ?? DEFAULT_THRESHOLD;
-}
+export type { PreprocessorConfig };
 
 /**
- * Preprocess non-English hyperscript into English.
- * Identical to preprocessToEnglish in preprocessor.ts but with slim imports.
- *
- * Handles _hyperscript feature prefixes (e.g. "on click", "on every keyup")
- * by stripping them, translating only the command portion, then reassembling.
+ * Preprocess non-English hyperscript into English (slim imports).
  */
-export function preprocessToEnglish(
-  src: string,
-  lang: string,
-  config: Partial<PreprocessorConfig> = {}
-): string {
-  const cfg = { ...DEFAULT_CONFIG, ...config };
-
-  // Try translating the full string first
-  const fullResult = tryTranslateWithStrategies(src, lang, cfg);
-  if (fullResult !== null) return fullResult;
-
-  // If full translation failed, try stripping event/feature prefix
-  const stripped = stripEventPrefix(src);
-  if (stripped) {
-    const translated = tryTranslateWithStrategies(stripped.commands, lang, cfg);
-    if (translated !== null) return stripped.prefix + translated;
-  }
-
-  return src;
-}
-
-function tryTranslateWithStrategies(
-  src: string,
-  lang: string,
-  cfg: PreprocessorConfig
-): string | null {
-  if (cfg.strategy === 'semantic' || cfg.strategy === 'auto') {
-    const threshold = resolveThreshold(cfg.confidenceThreshold, lang);
-    const result = trySemanticTranslation(src, lang, threshold);
-    if (result !== null) return result;
-  }
-
-  if ((cfg.strategy === 'auto' || cfg.strategy === 'i18n') && cfg.i18nToEnglish) {
-    const result = tryI18nTranslation(src, lang, cfg.i18nToEnglish);
-    if (result !== null) return result;
-  }
-
-  return null;
-}
-
-/** Match _hyperscript event handler prefix. */
-const EVENT_PREFIX_RE =
-  /^(on\s+(?:every\s+)?[\w-]+(?:\[.*?\])?(?:\.[\w-]+(?:\([^)]*\))?)*(?:\s+from\s+\S+)?(?:\s+queue\s+\w+)?\s+)/;
-
-function stripEventPrefix(src: string): { prefix: string; commands: string } | null {
-  const match = src.match(EVENT_PREFIX_RE);
-  if (!match) return null;
-  const prefix = match[1];
-  const commands = src.slice(prefix.length);
-  if (!commands) return null;
-  return { prefix, commands };
-}
-
-function trySemanticTranslation(src: string, lang: string, threshold: number): string | null {
-  try {
-    const statements = splitStatements(src, lang);
-    if (statements.length > 1) {
-      return translateCompound(statements, lang, threshold);
-    }
-
-    if (!isLanguageRegistered(lang)) return null;
-
+export const preprocessToEnglish = createPreprocessToEnglish({
+  isLanguageRegistered,
+  tryGetProfile,
+  translateSingle(src, lang, threshold) {
     const result = parseWithConfidence(src, lang);
     if (result.confidence < threshold || !result.node) return null;
 
     return renderToHyperscript(result.node);
-  } catch {
-    return null;
-  }
-}
-
-function tryI18nTranslation(
-  src: string,
-  lang: string,
-  toEnglish: (input: string, locale: string) => string
-): string | null {
-  try {
-    const result = toEnglish(src, lang);
-    return result !== src ? result : null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Get all "then" keyword forms for a language (primary + alternatives).
- * Falls back to English "then" if profile is unavailable.
- */
-function getThenKeywords(lang: string): string[] {
-  const keywords = ['then']; // Always include English
-  const profile = tryGetProfile(lang);
-  if (profile?.keywords?.then) {
-    const kw = profile.keywords.then;
-    if (kw.primary && kw.primary !== 'then') keywords.push(kw.primary);
-    if (kw.alternatives) {
-      for (const alt of kw.alternatives) {
-        if (!keywords.includes(alt)) keywords.push(alt);
-      }
-    }
-  }
-  return keywords;
-}
-
-function splitStatements(src: string, lang: string): string[] {
-  const thenWords = getThenKeywords(lang);
-  // Escape regex special chars and build pattern
-  const escaped = thenWords.map(w => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
-  const pattern = new RegExp(`\\s+(?:${escaped.join('|')})\\s+`, 'i');
-
-  const lines = src
-    .split('\n')
-    .map(l => l.trim())
-    .filter(l => l.length > 0);
-  const result: string[] = [];
-  for (const line of lines) {
-    const parts = line.split(pattern);
-    result.push(...parts);
-  }
-  return result;
-}
-
-function translateCompound(statements: string[], lang: string, threshold: number): string | null {
-  const translated: string[] = [];
-  for (const stmt of statements) {
-    const result = trySemanticTranslation(stmt.trim(), lang, threshold);
-    if (result === null) return null;
-    translated.push(result);
-  }
-  return translated.join(' then ');
-}
+  },
+});

--- a/packages/hyperscript-adapter/test/fixtures/preprocessor-parity.json
+++ b/packages/hyperscript-adapter/test/fixtures/preprocessor-parity.json
@@ -1,0 +1,263 @@
+[
+  {
+    "lang": "es",
+    "input": "alternar .active",
+    "full": "toggle .active",
+    "slim": "toggle .active"
+  },
+  {
+    "lang": "ja",
+    "input": ".active を 切り替え",
+    "full": "toggle .active",
+    "slim": "toggle .active"
+  },
+  {
+    "lang": "ko",
+    "input": ".active 을 토글",
+    "full": "toggle .active",
+    "slim": "toggle .active"
+  },
+  {
+    "lang": "zh",
+    "input": "切换 .active",
+    "full": "toggle .active",
+    "slim": "切换 .active"
+  },
+  {
+    "lang": "fr",
+    "input": "basculer .active",
+    "full": "toggle .active",
+    "slim": "toggle .active"
+  },
+  {
+    "lang": "ar",
+    "input": "بدّل .active",
+    "full": "toggle .active",
+    "slim": "toggle .active"
+  },
+  {
+    "lang": "es",
+    "input": "agregar .highlight en #box",
+    "full": "add .highlight to #box",
+    "slim": "add .highlight to #box"
+  },
+  {
+    "lang": "ja",
+    "input": "#box に .highlight を 追加",
+    "full": "add .highlight to #box",
+    "slim": "add .highlight to #box"
+  },
+  {
+    "lang": "ko",
+    "input": "#box 에 .highlight 을 추가",
+    "full": "add .highlight to #box",
+    "slim": "add .highlight to #box"
+  },
+  {
+    "lang": "fr",
+    "input": "ajouter .highlight sur #box",
+    "full": "add .highlight to #box",
+    "slim": "add .highlight to #box"
+  },
+  {
+    "lang": "ar",
+    "input": "أضف .highlight إلى #box",
+    "full": "add .highlight to #box",
+    "slim": "add .highlight to #box"
+  },
+  {
+    "lang": "es",
+    "input": "quitar .hidden de yo",
+    "full": "remove .hidden",
+    "slim": "remove .hidden"
+  },
+  {
+    "lang": "ja",
+    "input": "自分 から .hidden を 削除",
+    "full": "remove .hidden",
+    "slim": "remove .hidden"
+  },
+  {
+    "lang": "ko",
+    "input": "나 에서 .hidden 을 제거",
+    "full": "remove .hidden",
+    "slim": "remove .hidden"
+  },
+  {
+    "lang": "fr",
+    "input": "supprimer .hidden de moi",
+    "full": "remove .hidden",
+    "slim": "remove .hidden"
+  },
+  {
+    "lang": "es",
+    "input": "poner \"hello\" en #msg",
+    "full": "put \"hello\" into #msg",
+    "slim": "put \"hello\" into #msg"
+  },
+  {
+    "lang": "ja",
+    "input": "\"hello\" を #msg に 置く",
+    "full": "put \"hello\" into #msg",
+    "slim": "put \"hello\" into #msg"
+  },
+  {
+    "lang": "ko",
+    "input": "\"hello\" 을 #msg 에 넣다",
+    "full": "put \"hello\" into #msg",
+    "slim": "put \"hello\" into #msg"
+  },
+  {
+    "lang": "fr",
+    "input": "mettre \"hello\" sur #msg",
+    "full": "put \"hello\" into #msg",
+    "slim": "put \"hello\" into #msg"
+  },
+  {
+    "lang": "es",
+    "input": "establecer x a 5",
+    "full": "set x to 5",
+    "slim": "establecer x a 5"
+  },
+  {
+    "lang": "ja",
+    "input": "x を 5 に 設定",
+    "full": "set x to 5",
+    "slim": "set x to 5"
+  },
+  {
+    "lang": "zh",
+    "input": "设置 x 为 5",
+    "full": "set x to 5",
+    "slim": "设置 x 为 5"
+  },
+  {
+    "lang": "es",
+    "input": "mostrar #modal",
+    "full": "show #modal",
+    "slim": "show #modal"
+  },
+  {
+    "lang": "es",
+    "input": "ocultar #tooltip",
+    "full": "hide #tooltip",
+    "slim": "hide #tooltip"
+  },
+  {
+    "lang": "ja",
+    "input": "#modal を 表示",
+    "full": "show #modal",
+    "slim": "show #modal"
+  },
+  {
+    "lang": "ja",
+    "input": "#tooltip を 非表示",
+    "full": "hide #tooltip",
+    "slim": "hide #tooltip"
+  },
+  {
+    "lang": "ar",
+    "input": "أظهر #modal",
+    "full": "show #modal",
+    "slim": "show #modal"
+  },
+  {
+    "lang": "ar",
+    "input": "أخفِ #tooltip",
+    "full": "hide #tooltip",
+    "slim": "hide #tooltip"
+  },
+  {
+    "lang": "es",
+    "input": "alternar .active entonces poner \"ok\" en #msg",
+    "full": "toggle .active then put \"ok\" into #msg",
+    "slim": "toggle .active then put \"ok\" into #msg"
+  },
+  {
+    "lang": "es",
+    "input": "alternar .active then mostrar #modal",
+    "full": "toggle .active then show #modal",
+    "slim": "toggle .active then show #modal"
+  },
+  {
+    "lang": "es",
+    "input": "alternar .active\nmostrar #modal",
+    "full": "toggle .active then show #modal",
+    "slim": "toggle .active then show #modal"
+  },
+  {
+    "lang": "ja",
+    "input": ".active を 切り替え それから #modal を 表示",
+    "full": "toggle .active then show #modal",
+    "slim": "toggle .active then show #modal"
+  },
+  {
+    "lang": "es",
+    "input": "on click alternar .active",
+    "full": "on click toggle .active",
+    "slim": "on click toggle .active"
+  },
+  {
+    "lang": "es",
+    "input": "on every keyup establecer x a 5",
+    "full": "on every keyup set x to 5",
+    "slim": "on every keyup establecer x a 5"
+  },
+  {
+    "lang": "es",
+    "input": "on click.debounce(300) alternar .active",
+    "full": "on click.debounce(300) toggle .active",
+    "slim": "on click.debounce(300) toggle .active"
+  },
+  {
+    "lang": "es",
+    "input": "on keyup[key=='Enter'] establecer x a 1",
+    "full": "on keyup[key=='Enter'] set x to 1",
+    "slim": "on keyup[key=='Enter'] establecer x a 1"
+  },
+  {
+    "lang": "es",
+    "input": "on click from body alternar .active",
+    "full": "on click from body toggle .active",
+    "slim": "on click from body toggle .active"
+  },
+  {
+    "lang": "ja",
+    "input": "on click .active を 切り替え",
+    "full": "on click toggle .active",
+    "slim": "on click toggle .active"
+  },
+  {
+    "lang": "es",
+    "input": "xyz abc 123",
+    "full": "xyz abc 123",
+    "slim": "xyz abc 123"
+  },
+  {
+    "lang": "es",
+    "input": "xyz abc 123",
+    "config": {
+      "confidenceThreshold": 1
+    },
+    "full": "xyz abc 123",
+    "slim": "xyz abc 123"
+  },
+  {
+    "lang": "en",
+    "input": "toggle .active",
+    "full": "toggle .active",
+    "slim": "toggle .active"
+  },
+  {
+    "lang": "xx",
+    "input": "toggle .active",
+    "full": "toggle .active",
+    "slim": "toggle .active"
+  },
+  {
+    "lang": "es",
+    "input": "toggle .active",
+    "full": "toggle .active",
+    "slim": "toggle .active"
+  }
+]

--- a/packages/hyperscript-adapter/test/parity-harness.ts
+++ b/packages/hyperscript-adapter/test/parity-harness.ts
@@ -1,0 +1,121 @@
+/**
+ * Shared harness for the full-vs-slim preprocessor parity oracle.
+ *
+ * Single source of truth for the parity corpus — the generator script
+ * (scripts/generate-parity-fixture.ts) and BOTH parity test files execute
+ * exactly these rows, so the fixture can never drift from what the tests
+ * run.
+ *
+ * DELIBERATELY imports neither preprocessor. The full package wires the
+ * rich pattern builder (`buildPatternsForLanguage`, handcrafted patterns
+ * included) into the registry as an import side effect; slim bundles wire
+ * the schema-only `generatePatternsForLanguage`. Shipped bundles never
+ * share a registry — but under vitest's src aliases all modules in one
+ * test file DO, and whoever calls setPatternGenerator last would silently
+ * reconfigure the other path (measured: the full path loses exactly the
+ * handcrafted-pattern rows). So each parity test file imports only its own
+ * path's chain, and the two files never meet in one module graph:
+ *
+ *   - preprocessor-parity.full.test.ts — full path only
+ *   - preprocessor-parity.slim.test.ts — slim path + wireSlimPath()
+ *
+ * The corpus deliberately reaches every branch of the preprocessors'
+ * shared skeleton: single commands across word orders (SVO/SOV/VSO),
+ * compound splitting (localized + English `then`, newlines), event-prefix
+ * stripping (plain, `every`, modifier, filter, `from`), confidence-gated
+ * fallback, English identity, and unregistered languages.
+ */
+
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import type { PreprocessorConfig } from '../src/preprocessor';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export interface ParityRow {
+  lang: string;
+  input: string;
+  config?: Partial<PreprocessorConfig>;
+}
+
+export interface FixtureRow extends ParityRow {
+  full: string;
+  slim: string;
+}
+
+/** Languages the slim path registers (one per word order plus the rest of
+ *  the unit-test matrix). Keep in sync with wireSlimPath in the slim file. */
+export const SLIM_LANGS = ['es', 'ja', 'ko', 'zh', 'fr', 'ar'] as const;
+
+export const PARITY_CORPUS: ParityRow[] = [
+  // ── Single commands: the unit-test matrix (SVO / SOV / VSO) ──────
+  { lang: 'es', input: 'alternar .active' },
+  { lang: 'ja', input: '.active を 切り替え' },
+  { lang: 'ko', input: '.active 을 토글' },
+  { lang: 'zh', input: '切换 .active' },
+  { lang: 'fr', input: 'basculer .active' },
+  { lang: 'ar', input: 'بدّل .active' },
+  { lang: 'es', input: 'agregar .highlight en #box' },
+  { lang: 'ja', input: '#box に .highlight を 追加' },
+  { lang: 'ko', input: '#box 에 .highlight 을 추가' },
+  { lang: 'fr', input: 'ajouter .highlight sur #box' },
+  { lang: 'ar', input: 'أضف .highlight إلى #box' },
+  { lang: 'es', input: 'quitar .hidden de yo' },
+  { lang: 'ja', input: '自分 から .hidden を 削除' },
+  { lang: 'ko', input: '나 에서 .hidden 을 제거' },
+  { lang: 'fr', input: 'supprimer .hidden de moi' },
+  { lang: 'es', input: 'poner "hello" en #msg' },
+  { lang: 'ja', input: '"hello" を #msg に 置く' },
+  { lang: 'ko', input: '"hello" 을 #msg 에 넣다' },
+  { lang: 'fr', input: 'mettre "hello" sur #msg' },
+  { lang: 'es', input: 'establecer x a 5' },
+  { lang: 'ja', input: 'x を 5 に 設定' },
+  { lang: 'zh', input: '设置 x 为 5' },
+  { lang: 'es', input: 'mostrar #modal' },
+  { lang: 'es', input: 'ocultar #tooltip' },
+  { lang: 'ja', input: '#modal を 表示' },
+  { lang: 'ja', input: '#tooltip を 非表示' },
+  { lang: 'ar', input: 'أظهر #modal' },
+  { lang: 'ar', input: 'أخفِ #tooltip' },
+
+  // ── Compound statements: then-splitting in both languages ────────
+  { lang: 'es', input: 'alternar .active entonces poner "ok" en #msg' },
+  { lang: 'es', input: 'alternar .active then mostrar #modal' },
+  { lang: 'es', input: 'alternar .active\nmostrar #modal' },
+  { lang: 'ja', input: '.active を 切り替え それから #modal を 表示' },
+
+  // ── Event-prefix stripping ───────────────────────────────────────
+  { lang: 'es', input: 'on click alternar .active' },
+  { lang: 'es', input: 'on every keyup establecer x a 5' },
+  { lang: 'es', input: 'on click.debounce(300) alternar .active' },
+  { lang: 'es', input: "on keyup[key=='Enter'] establecer x a 1" },
+  { lang: 'es', input: 'on click from body alternar .active' },
+  { lang: 'ja', input: 'on click .active を 切り替え' },
+
+  // ── Fallback / identity / unregistered ───────────────────────────
+  { lang: 'es', input: 'xyz abc 123' },
+  { lang: 'es', input: 'xyz abc 123', config: { confidenceThreshold: 1.0 } },
+  { lang: 'en', input: 'toggle .active' },
+  { lang: 'xx', input: 'toggle .active' },
+  { lang: 'es', input: 'toggle .active' }, // already-English text under an es scope
+];
+
+export function loadFixture(): FixtureRow[] {
+  return JSON.parse(
+    readFileSync(path.join(__dirname, 'fixtures', 'preprocessor-parity.json'), 'utf8')
+  );
+}
+
+/** The rows where the two paths are KNOWN to disagree today: the slim
+ *  path's schema-only pattern generator lacks the handcrafted patterns
+ *  that cover zh `切换` toggle and the `set` command (bare and under event
+ *  prefixes). Burn these down by closing the slim generator gap, then
+ *  regenerate the fixture in the same change. */
+export const KNOWN_DIVERGENCES: Array<[lang: string, input: string]> = [
+  ['zh', '切换 .active'],
+  ['es', 'establecer x a 5'],
+  ['zh', '设置 x 为 5'],
+  ['es', 'on every keyup establecer x a 5'],
+  ['es', "on keyup[key=='Enter'] establecer x a 1"],
+];

--- a/packages/hyperscript-adapter/test/preprocessor-parity.full.test.ts
+++ b/packages/hyperscript-adapter/test/preprocessor-parity.full.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Full-path half of the preprocessor parity ratchet.
+ *
+ * Recomputes the shared corpus through the FULL preprocessor and diffs
+ * against its column of the committed snapshot
+ * (test/fixtures/preprocessor-parity.json, written by
+ * scripts/generate-parity-fixture.ts). The slim half lives in
+ * preprocessor-parity.slim.test.ts — a separate FILE on purpose: the two
+ * paths wire different pattern generators into the registry, and under
+ * vitest's shared-src aliases one file = one registry, so importing both
+ * chains together lets whichever wires last silently reconfigure the other
+ * (see parity-harness.ts). Two files = two module graphs = shipped reality.
+ *
+ * Why absolute pins rather than comparing the paths to each other: a
+ * refactor that changes both paths identically (the F4 shared-skeleton
+ * extraction) would be invisible to a live comparison — the snapshot is
+ * the oracle that makes such a refactor provably behavior-preserving.
+ *
+ * On failure: if you changed preprocessor/semantic behavior on purpose,
+ * regenerate (`npx tsx scripts/generate-parity-fixture.ts`) and commit the
+ * diff. Otherwise you caught unintended drift — fix the code, not the
+ * fixture. NOTE: a stale @lokascript/semantic dist makes the GENERATOR
+ * vacuous — rebuild deps first (`npm run check:fresh` at the repo root).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { preprocessToEnglish } from '../src/preprocessor';
+import { PARITY_CORPUS, KNOWN_DIVERGENCES, loadFixture } from './parity-harness';
+
+const fixture = loadFixture();
+
+describe('preprocessor parity — full path', () => {
+  it('fixture and corpus are the same shape (regenerate after editing the corpus)', () => {
+    expect(fixture.map(r => [r.lang, r.input])).toEqual(
+      PARITY_CORPUS.map(r => [r.lang, r.input])
+    );
+  });
+
+  it('the committed full-vs-slim divergence set is exactly the known one', () => {
+    const divergent = fixture.filter(r => r.full !== r.slim).map(r => [r.lang, r.input]);
+    expect(divergent).toEqual(KNOWN_DIVERGENCES);
+  });
+
+  it.each(fixture.map((row, i) => [row.lang, row.input, i] as const))(
+    '[%s] %s — full path matches its snapshot',
+    (_lang, _input, i) => {
+      const row = fixture[i];
+      expect(preprocessToEnglish(row.input, row.lang, PARITY_CORPUS[i].config ?? {})).toBe(
+        row.full
+      );
+    }
+  );
+});

--- a/packages/hyperscript-adapter/test/preprocessor-parity.slim.test.ts
+++ b/packages/hyperscript-adapter/test/preprocessor-parity.slim.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Slim-path half of the preprocessor parity ratchet.
+ *
+ * See preprocessor-parity.full.test.ts for the design rationale (absolute
+ * snapshot pins; two files so the two paths' registry wiring never shares
+ * a module graph). This file must NEVER import `@lokascript/semantic` (the
+ * full package) — only `/core` and `/languages/*`, the same chain a
+ * per-language bundle entry uses. The full package's import side effect
+ * wires the rich handcrafted-pattern builder, which would mask the slim
+ * path's real (schema-only) behavior.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import {
+  setPatternGenerator,
+  generatePatternsForLanguage,
+  type LanguageProfile,
+} from '@lokascript/semantic/core';
+import { preprocessToEnglish } from '../src/slim-preprocessor';
+import { PARITY_CORPUS, loadFixture } from './parity-harness';
+
+// Side-effect language registrations, same as per-language bundle entries.
+// Keep in sync with SLIM_LANGS in parity-harness.ts.
+import '@lokascript/semantic/languages/es';
+import '@lokascript/semantic/languages/ja';
+import '@lokascript/semantic/languages/ko';
+import '@lokascript/semantic/languages/zh';
+import '@lokascript/semantic/languages/fr';
+import '@lokascript/semantic/languages/ar';
+
+const fixture = loadFixture();
+
+beforeAll(() => {
+  // Same wiring as src/bundles/shared.ts.
+  setPatternGenerator((profile: LanguageProfile) => generatePatternsForLanguage(profile));
+});
+
+describe('preprocessor parity — slim path', () => {
+  it.each(fixture.map((row, i) => [row.lang, row.input, i] as const))(
+    '[%s] %s — slim path matches its snapshot',
+    (_lang, _input, i) => {
+      const row = fixture[i];
+      expect(preprocessToEnglish(row.input, row.lang, PARITY_CORPUS[i].config ?? {})).toBe(
+        row.slim
+      );
+    }
+  );
+});


### PR DESCRIPTION
Step 4 of the hyperscript-adapter review's sequenced plan (F4), on top of #895/#896/#897.

## The duplication, and what it had already cost

`preprocessor.ts` and `slim-preprocessor.ts` were ~170 near-identical lines each ("Identical to preprocessToEnglish … but with slim imports") and had already diverged: the full path had an `en` early-return and a "confident-but-nodeless → `translate()`" rescue the slim path lacked. This is the dual-renderer drift pattern the R1 arc documented.

## Extraction

`preprocessor-core.ts` now holds the shared skeleton — strategy ordering (semantic → optional i18n), compound `then`/newline splitting, event-prefix stripping, threshold resolution, the return-original fallback — **once**. The two paths inject only what genuinely differs: `translateSingle` (semantic's `parseSemantic` + `render('en')` + `translate()` rescue, vs `parseWithConfidence` + the custom hyperscript renderer) and their registry/profile lookups. Net **−365 duplicated lines**. One deliberate alignment, called out in code: the slim path gains the full path's `en` early-return (it is a mangle guard; its absence was drift, not design).

## The parity oracle (built before the refactor)

Per the repo's parity-oracle convention, a 43-row corpus (word orders × commands, compound splitting, five event-prefix shapes, confidence fallback, en identity, unregistered langs) is snapshot-pinned **byte-exactly per path** in `test/fixtures/preprocessor-parity.json` (regenerate: `npx tsx scripts/generate-parity-fixture.ts`). Absolute pins rather than live full-vs-slim comparison, because a refactor that changes both paths identically would be invisible to comparing them to each other.

- **Byte-identical regeneration across the refactor** (same shasum before/after) — the extraction is provably behavior-preserving over the corpus.
- **Mutation probe**: disabling the shared prefix-strip reddens the prefix rows in *both* halves — one shared-code mutation, both paths caught.
- **The 5 known full-vs-slim divergences are committed data** (an explicit expectation): the full package wires the rich handcrafted-pattern builder, slim bundles the schema-only generator; zh `切换` toggle and es/zh `set` (bare + under prefixes) are the measured gap. Burning that down means closing the slim generator gap and regenerating the fixture in the same change.
- **A vitest trap worth knowing, now documented in the package CLAUDE.md**: under the src aliases, one test file = one module graph = one semantic registry, so importing both chains in one file lets whichever calls `setPatternGenerator` last silently reconfigure the *other* path (measured — the full path lost exactly the handcrafted rows). Hence two parity test files; the fixture generator runs under tsx/dist where the registries fork the same way shipped bundles do.

## Also in this session's review arc (recorded, not in this PR)

The F5 "reorder to whole-string-first" prescription was **measured and vetoed**: over all 3703 patterns.db translation rows, whole-first wins 207 rows (all repeat-**body** corruptions caused by the current split-rejoin hardcoding ` then ` into loop bodies) but loses 73 true sequences and worsens the rest, because semantic's en renderer drops the `then` connector between sequenced commands — invalid single-line hyperscript. The enabling fix is upstream in `@lokascript/semantic`'s sequence rendering; the handoff's F5 section carries the full brief.

## Verification

- 316/316 vitest (was 228; +88 parity), 35/35 e2e against the rebuilt bundle, typecheck clean
- Bundle sizes moved ~140 bytes (comment/JSDoc noise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)