### PR TITLE
Fix the CI-invisible @comprehensive failures: hx-live reactivity + put/DocumentFragment

### DIFF
--- a/examples/hx-v4-i18n/multilang-page.html
+++ b/examples/hx-v4-i18n/multilang-page.html
@@ -104,9 +104,9 @@
     </section>
 
     <section lang="ar" dir="rtl">
-      <h2>العربية <span class="tag">hx-احصل / hx-هدف</span></h2>
+      <h2>العربية <span class="tag">hx-احصل / hx-الهدف</span></h2>
       <p>الزر يستخدم <code>hx-احصل</code> (الشكل العربي لـ <code>hx-get</code>).</p>
-      <button hx-احصل="/api/مستخدمين" hx-هدف="#out-ar">تحميل المستخدمين</button>
+      <button hx-احصل="/api/مستخدمين" hx-الهدف="#out-ar">تحميل المستخدمين</button>
       <div class="out" id="out-ar">(انقر الزر)</div>
     </section>
 

--- a/packages/core/src/commands/dom/put.test.ts
+++ b/packages/core/src/commands/dom/put.test.ts
@@ -641,6 +641,59 @@ describe('PutCommand', () => {
     });
   });
 
+  describe('Execution - DocumentFragment content', () => {
+    // `fetch … as html` resolves to a DocumentFragment, and the htmx-compat
+    // layer's entire swap path is `fetch … as html then put it into <target>`.
+    // Before this was handled, every such swap inserted the literal string
+    // "[object DocumentFragment]".
+    function fragmentOf(html: string): DocumentFragment {
+      const tpl = document.createElement('template');
+      tpl.innerHTML = html;
+      const frag = document.createDocumentFragment();
+      Array.from(tpl.content.childNodes).forEach(n => frag.appendChild(n));
+      return frag;
+    }
+
+    it("inserts a fragment's children rather than stringifying it", async () => {
+      const context = createMockContext();
+      const target = createMockElement('target');
+
+      await command.execute(
+        { value: fragmentOf('<p>Fetched: /api/users</p>'), targets: [target], position: 'into' },
+        context
+      );
+
+      expect(target.textContent).toBe('Fetched: /api/users');
+      expect(target.querySelector('p')).not.toBeNull();
+      expect(target.textContent).not.toContain('DocumentFragment');
+    });
+
+    it('appends fragment children at a position', async () => {
+      const context = createMockContext();
+      const target = createMockElement('target');
+      target.innerHTML = '<span>first</span>';
+
+      await command.execute(
+        { value: fragmentOf('<span>second</span>'), targets: [target], position: 'append' },
+        context
+      );
+
+      expect(target.textContent).toBe('firstsecond');
+    });
+
+    it('inserts a bare text node without stringifying', async () => {
+      const context = createMockContext();
+      const target = createMockElement('target');
+
+      await command.execute(
+        { value: document.createTextNode('plain text'), targets: [target], position: 'into' },
+        context
+      );
+
+      expect(target.textContent).toBe('plain text');
+    });
+  });
+
   describe('Execution - Property Setting', () => {
     it('should set element property via memberPath', async () => {
       const context = createMockContext();

--- a/packages/core/src/commands/dom/put.ts
+++ b/packages/core/src/commands/dom/put.ts
@@ -15,7 +15,7 @@
 import type { ExecutionContext, TypedExecutionContext } from '../../types/core';
 import type { ASTNode, ExpressionNode } from '../../types/base-types';
 import type { ExpressionEvaluator } from '../../core/expression-evaluator';
-import { isHTMLElement } from '../../utils/element-check';
+import { isHTMLElement, isInsertableNode } from '../../utils/element-check';
 import {
   isPropertyTargetString,
   resolveAnyPropertyTarget,
@@ -300,6 +300,15 @@ export class PutCommand implements DecoratedCommand {
     if (Array.isArray(v) && v.length > 0 && v.every(isHTMLElement)) {
       return v as HTMLElement[];
     }
+    // `fetch … as html` resolves to a DocumentFragment (see FetchCommand's
+    // parseHTML), and the htmx-compat layer's whole swap path is
+    // `fetch … as html then put it into <target>`. Without this branch the
+    // fragment fell to String(v) and every such swap inserted the literal
+    // text "[object DocumentFragment]". Insertion helpers accept any Node —
+    // insertBefore/appendChild splice a fragment's children in place — so
+    // pass it straight through. Checked after the Element and array cases,
+    // which have their own handling.
+    if (isInsertableNode(v)) return v as unknown as HTMLElement;
     return v == null ? '' : String(v);
   }
 

--- a/packages/core/src/commands/helpers/dom-mutation.ts
+++ b/packages/core/src/commands/helpers/dom-mutation.ts
@@ -10,7 +10,7 @@
  * - Safe DOM manipulation utilities
  */
 
-import { isHTMLElement } from '../../utils/element-check';
+import { isHTMLElement, isInsertableNode } from '../../utils/element-check';
 
 /**
  * Extended insert positions (standard DOM InsertPosition plus 'replace')
@@ -98,7 +98,7 @@ export function looksLikeHTML(str: string): boolean {
  */
 export function insertContent(
   target: HTMLElement,
-  content: string | HTMLElement,
+  content: string | Node,
   position: ContentInsertPosition
 ): void {
   if (position === 'replace') {
@@ -106,10 +106,13 @@ export function insertContent(
     return;
   }
 
-  if (isHTMLElement(content)) {
+  // Any insertable Node — Element, Text, or the DocumentFragment that
+  // `fetch … as html` produces — goes through the node path. Only strings
+  // are parsed/escaped as markup.
+  if (isInsertableNode(content)) {
     insertElement(target, content, position);
   } else {
-    insertText(target, content, position);
+    insertText(target, content as string, position);
   }
 }
 
@@ -122,7 +125,7 @@ export function insertContent(
  */
 export function insertContentSemantic(
   target: HTMLElement,
-  content: string | HTMLElement,
+  content: string | Node,
   position: SemanticPosition
 ): void {
   insertContent(target, content, toInsertPosition(position));
@@ -134,8 +137,8 @@ export function insertContentSemantic(
  * @param target - Target element
  * @param content - New content
  */
-function insertReplace(target: HTMLElement, content: string | HTMLElement): void {
-  if (isHTMLElement(content)) {
+function insertReplace(target: HTMLElement, content: string | Node): void {
+  if (isInsertableNode(content)) {
     target.innerHTML = '';
     target.appendChild(content);
   } else {
@@ -154,11 +157,7 @@ function insertReplace(target: HTMLElement, content: string | HTMLElement): void
  * @param element - Element to insert
  * @param position - Insert position
  */
-function insertElement(
-  target: HTMLElement,
-  element: HTMLElement,
-  position: ContentInsertPosition
-): void {
+function insertElement(target: HTMLElement, element: Node, position: ContentInsertPosition): void {
   switch (position) {
     case 'beforebegin':
       target.parentElement?.insertBefore(element, target);

--- a/packages/core/src/parser/runtime.ts
+++ b/packages/core/src/parser/runtime.ts
@@ -539,6 +539,23 @@ function evaluateLiteral(node: LiteralNode): unknown {
 async function evaluateIdentifier(node: IdentifierNode, context: ExecutionContext): Promise<any> {
   const name = node.name;
 
+  // Reactive dependency tracking for global reads happens HERE, before any
+  // presence check, because a read of an *unset* global is still a read: an
+  // effect that renders `$count` must re-run when `$count` is first assigned.
+  // Firing only inside the `globals.has(name)` branches below made a `live`
+  // block subscribe to nothing on its first pass (the common case — the var
+  // usually doesn't exist yet), so the block never re-rendered, or re-rendered
+  // one write late once some other path created the variable.
+  //
+  // Only unambiguously-global forms qualify: `$name` and the explicit-global
+  // `::name` (scope: 'global'). A bare identifier may resolve to a local, a
+  // context property or a JS built-in, and must not register a global dep.
+  if (name.startsWith('$')) {
+    notifyGlobalRead(name.slice(1), context);
+  } else if ((node as { scope?: string }).scope === 'global') {
+    notifyGlobalRead(name, context);
+  }
+
   // Context variables. Upstream aliases: `my`/`I` → me, `your`/`yourself` →
   // you, `its` → it. Matches `_hyperscript/src/core/runtime.js:resolveSymbol`.
   if (name === 'me' || name === 'my' || name === 'I') {
@@ -567,7 +584,7 @@ async function evaluateIdentifier(node: IdentifierNode, context: ExecutionContex
   // bare, so we pass it through unchanged. Falls through to the normal lookups
   // (incl. globalThis) when the global isn't present in context.
   if ((node as { scope?: string }).scope === 'global' && context.globals?.has(name)) {
-    notifyGlobalRead(name, context);
+    // read hook already fired at the top of this function
     return context.globals.get(name);
   }
   // Element-scoped `:name` (parser tags these `scope: 'element'`). Reads from the
@@ -581,14 +598,12 @@ async function evaluateIdentifier(node: IdentifierNode, context: ExecutionContex
     return context.locals.get(name);
   }
   if (context.globals && context.globals.has(name)) {
-    if (name.startsWith('$')) notifyGlobalRead(name.slice(1), context);
     return context.globals.get(name);
   }
   if (name.startsWith('$') && context.globals && context.globals.has(name.slice(1))) {
     // Hyperscript convention: `$name` identifiers look up `name` in globals
     // (matches how setVariableValue stores them). Covers both legacy parse
     // paths (identifier with `$` prefix) and the newer `globalVariable` path.
-    notifyGlobalRead(name.slice(1), context);
     return context.globals.get(name.slice(1));
   }
   if ((context as any)[name] !== undefined) {

--- a/packages/core/src/utils/element-check.ts
+++ b/packages/core/src/utils/element-check.ts
@@ -83,6 +83,27 @@ export function isElement(value: unknown): value is Element {
 }
 
 /**
+ * Cross-realm safe check for a Node the DOM insertion methods accept.
+ *
+ * Covers Element (1), Text (3) and DocumentFragment (11) — the node kinds
+ * `insertBefore`/`appendChild` splice into a parent. Notably a
+ * DocumentFragment is what `fetch … as html` resolves to, so commands that
+ * insert content must accept it rather than stringifying to
+ * "[object DocumentFragment]".
+ *
+ * Deliberately excludes Document (9) and DocumentType (10), which cannot be
+ * inserted into an element.
+ *
+ * @param value - Value to check
+ * @returns True if value is a Node that can be inserted into an element
+ */
+export function isInsertableNode(value: unknown): value is Node {
+  if (value === null || typeof value !== 'object') return false;
+  const nodeType = (value as { nodeType?: unknown }).nodeType;
+  return nodeType === 1 || nodeType === 3 || nodeType === 11;
+}
+
+/**
  * Cross-realm safe EventTarget check using duck-typing.
  *
  * @param value - Value to check

--- a/packages/reactivity/src/integration.test.ts
+++ b/packages/reactivity/src/integration.test.ts
@@ -112,6 +112,139 @@ describe('@hyperfixi/reactivity — integration', () => {
 
       document.body.removeChild(el);
     });
+
+    // Regression: reading a global that does not exist YET is still a read.
+    // Every notifyGlobalRead call used to sit inside a `globals.has(name)`
+    // guard, so a live block whose variable was unset on first pass — the
+    // common case for a counter starting from nothing — subscribed to
+    // nothing and never re-rendered. The pre-seeded test above could not see
+    // it. Browser symptom: examples/hx-v4-i18n/live-multilang.html counters
+    // stuck at 0.
+    it('subscribes to a global that is UNSET on the first pass', async () => {
+      const el = document.createElement('div');
+      document.body.appendChild(el);
+      const ctx = createContext(el);
+      // deliberately no ctx.globals.set('count', …)
+
+      const r = parse('live\n  put $count into me\nend');
+      expect(r.success).toBe(true);
+      await runtime.execute(r.node!, ctx);
+      await settle();
+
+      ctx.globals.set('count', 7);
+      reactive.notifyGlobal('count');
+      await settle();
+      expect(el.textContent).toBe('7');
+
+      document.body.removeChild(el);
+    });
+
+    it('subscribes through an `or` default when the global is unset', async () => {
+      const el = document.createElement('div');
+      document.body.appendChild(el);
+      const ctx = createContext(el);
+
+      const r = parse('live\n  put $count or 0 into me\nend');
+      expect(r.success).toBe(true);
+      await runtime.execute(r.node!, ctx);
+      await settle();
+      expect(el.textContent).toBe('0'); // the `or` default rendered
+
+      ctx.globals.set('count', 3);
+      reactive.notifyGlobal('count');
+      await settle();
+      expect(el.textContent).toBe('3');
+
+      document.body.removeChild(el);
+    });
+
+    // The tests above hand-fire `reactive.notifyGlobal(...)`, which proves the
+    // subscription but NOT the write path. This one drives the whole loop the
+    // way a page does — a second script does `set $count to …` — so a missing
+    // write-notify (or a write that bypasses setGlobal) fails here.
+    it('re-runs when a real `set $count` executes, with no manual notify', async () => {
+      const el = document.createElement('div');
+      document.body.appendChild(el);
+      const ctx = createContext(el);
+
+      const live = parse('live\n  put $count or 0 into me\nend');
+      expect(live.success).toBe(true);
+      await runtime.execute(live.node!, ctx);
+      await settle();
+      expect(el.textContent).toBe('0');
+
+      // Separate execution, separate context — exactly like a button handler.
+      // Contexts share ONE globals map at runtime (`getSharedGlobals()`), so
+      // the harness must share it too; a fresh Map here would make the test
+      // pass or fail for reasons the product never sees.
+      const writer = createContext(document.createElement('button'));
+      (writer as { globals: Map<string, unknown> }).globals = ctx.globals;
+      const setter = parse('set $count to 5');
+      expect(setter.success).toBe(true);
+      await runtime.execute(setter.node!, writer);
+      await settle();
+
+      expect(el.textContent).toBe('5');
+
+      document.body.removeChild(el);
+    });
+
+    // Regression: several `live` blocks on one page initialize concurrently
+    // (each is queued as its own microtask, and each body `await`s). Dependency
+    // capture uses a single "current effect" slot, so interleaved async runs
+    // can attribute one effect's reads to another — leaving blocks subscribed
+    // to nothing. Browser symptom: live-multilang.html's three counters froze
+    // while the single-counter page worked. One effect per test can never see
+    // this; this test needs THREE.
+    it('tracks dependencies correctly when several live blocks initialize concurrently', async () => {
+      const els = [0, 1, 2].map(() => {
+        const el = document.createElement('div');
+        document.body.appendChild(el);
+        return el;
+      });
+      const shared = new Map<string, unknown>();
+
+      for (const el of els) {
+        const ctx = createContext(el);
+        (ctx as { globals: Map<string, unknown> }).globals = shared;
+        const r = parse('live\n  put $count or 0 into me\nend');
+        expect(r.success).toBe(true);
+        // Deliberately NOT awaited between blocks — a page starts them all.
+        void runtime.execute(r.node!, ctx);
+      }
+      await settle();
+      expect(els.map(e => e.textContent)).toEqual(['0', '0', '0']);
+
+      shared.set('count', 4);
+      reactive.notifyGlobal('count');
+      await settle();
+
+      expect(els.map(e => e.textContent)).toEqual(['4', '4', '4']);
+
+      els.forEach(e => document.body.removeChild(e));
+    });
+
+    it('does not register a global dep for a bare (non-$) identifier', async () => {
+      const el = document.createElement('div');
+      document.body.appendChild(el);
+      const ctx = createContext(el);
+      ctx.locals.set('count', 1);
+
+      const r = parse('live\n  put count into me\nend');
+      expect(r.success).toBe(true);
+      await runtime.execute(r.node!, ctx);
+      await settle();
+      expect(el.textContent).toBe('1');
+
+      // A GLOBAL named `count` changing must not re-run a body that read the
+      // LOCAL `count` — otherwise the top-of-function hook is over-firing.
+      ctx.globals.set('count', 99);
+      reactive.notifyGlobal('count');
+      await settle();
+      expect(el.textContent).toBe('1');
+
+      document.body.removeChild(el);
+    });
   });
 
   describe('when ... changes', () => {

--- a/packages/reactivity/src/signals.ts
+++ b/packages/reactivity/src/signals.ts
@@ -162,6 +162,12 @@ interface DomHandler {
 
 export class Reactive {
   private currentEffect: Effect | null = null;
+  /**
+   * Tail of the effect-evaluation chain. `_runWithEffect` links onto this so
+   * only one effect owns the `currentEffect` slot at a time — see the comment
+   * there for why concurrent async effects otherwise lose their dependencies.
+   */
+  private trackingQueue: Promise<void> = Promise.resolve();
   private pending = new Set<Effect>();
   private scheduled = false;
 
@@ -189,17 +195,40 @@ export class Reactive {
    * which effect to subscribe.
    */
   async _runWithEffect(e: Effect, fn: () => unknown | Promise<unknown>): Promise<unknown> {
-    const prev = this.currentEffect;
-    this.currentEffect = e;
-    // Unsubscribe from previous deps before re-running. The expression will
-    // re-record whatever it actually reads this time, avoiding stale subs.
-    this._unsubscribeEffect(e);
-    e.dependencies.clear();
-    try {
-      return await fn();
-    } finally {
-      this.currentEffect = prev;
-    }
+    // Dependency capture keys off ONE `currentEffect` slot, but effect
+    // expressions are async (a `live` body awaits each command). Two effects
+    // evaluating concurrently would interleave across their await points and
+    // attribute each other's reads — or, once the inner one restored `prev`,
+    // leave the outer one tracking nothing at all. Three `live` blocks on a
+    // page (they all start in the same tick) reliably lost their
+    // subscriptions that way and froze.
+    //
+    // Serialize instead: each run waits for the previous one to finish, so
+    // the slot belongs to exactly one effect for the whole of its evaluation.
+    // Effect bodies are short DOM updates, and this only orders effect
+    // evaluation — it does not block the page.
+    const runExclusive = async (): Promise<unknown> => {
+      const prev = this.currentEffect;
+      this.currentEffect = e;
+      // Unsubscribe from previous deps before re-running. The expression will
+      // re-record whatever it actually reads this time, avoiding stale subs.
+      this._unsubscribeEffect(e);
+      e.dependencies.clear();
+      try {
+        return await fn();
+      } finally {
+        this.currentEffect = prev;
+      }
+    };
+
+    // Chain onto the tail of the queue, and keep the queue alive whether this
+    // run resolves or throws (callers already swallow effect errors).
+    const result = this.trackingQueue.then(runExclusive, runExclusive);
+    this.trackingQueue = result.then(
+      () => undefined,
+      () => undefined
+    );
+    return result;
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
`npm run test:comprehensive` has been failing on `main` — invisible to CI, because the `browser-tests` job runs only `--project=quick`, so the `@comprehensive` specs have never run there. Three real product bugs were hiding behind those failures, two of them affecting far more than the i18n fixtures that surfaced them.

## 1. Reading an unset global registered no reactive dependency

Every `notifyGlobalRead` call sat inside a `globals.has(name)` guard. A `live` block whose variable was unset on its first pass — the normal case for a counter that starts from nothing — therefore subscribed to nothing and never re-rendered.

The read hook now fires at the top of `evaluateIdentifier` for unambiguously-global forms (`$name`, `::name`) regardless of presence. Bare identifiers still do not register a global dep (they may resolve to a local, a context property, or a JS built-in) — pinned by a negative test.

The existing test could not catch this: it pre-seeded `ctx.globals` before running the block.

## 2. Concurrent effects clobbered each other's dependency capture

Dependency tracking keys off a single `currentEffect` slot, but effect expressions are async — a `live` body awaits each command. Effects initializing in the same tick interleaved across their await points, attributing each other's reads or, once the inner one restored `prev`, leaving the outer one tracking nothing.

That is why a page with **one** `hx-live` block worked while a page with **three** froze. Effect evaluation is now serialized through a promise chain, so the slot belongs to exactly one effect for the whole of its run.

Every existing reactivity test used a single effect, so none could see it. The new test uses three.

## 3. `put` stringified DocumentFragment content

`fetch … as html` resolves to a DocumentFragment, and the htmx-compat layer's entire swap path is `fetch … as html then put it into <target>`. `put` passed only `HTMLElement` through and sent everything else to `String(v)`, so **every such swap inserted the literal text `[object DocumentFragment]`**.

Adds `isInsertableNode` (Element / Text / DocumentFragment — the node kinds `insertBefore`/`appendChild` splice into a parent; Document and DocumentType deliberately excluded) and widens the insertion helpers from `string | HTMLElement` to `string | Node`. Fragments splice their children in place; only strings are still parsed as markup.

## Plus one fixture typo

`examples/hx-v4-i18n/multilang-page.html` used `hx-هدف` while the generated Arabic vocab maps `hx-الهدف` → `hx-target`. Unresolved, the target fell back to `me`, so the button overwrote its own label instead of the output div. A fixture bug, not a runtime one.

## Verification

- Both `@comprehensive` i18n-htmx specs now pass in Chromium.
- Core: 7,946 unit tests · reactivity: 50 · typecheck clean · `verify:reference` clean.
- New regression tests: unset-global subscribe, `or`-default subscribe, the real `set` write path with no manual notify, three-concurrent-blocks, the bare-identifier negative case, and three `put` fragment/text-node cases.

**Remaining 4 `@comprehensive` failures are not from this branch.** They are the View Transitions specs, caused by `startViewTransition` being invoked detached — already fixed in #904. I verified by applying that single file here: all four pass. Once both land, `test:comprehensive` is fully green.

**Merge order: land #904 first.** It also touches `put.ts` and `dom-mutation.ts`, so a small mechanical conflict is expected here; I'll rebase.

Worth considering separately: CI's `browser-tests` job only runs `--project=quick`, which is why three real bugs sat undetected. Running `@comprehensive` on a nightly schedule would have caught all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)