### PR TITLE
ci(browser-tests): run the comprehensive Playwright tier alongside quick

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1301,8 +1301,19 @@ jobs:
           echo "=== i18n bundle check ==="
           ls -la packages/i18n/dist/lokascript-i18n.min.js || echo "MISSING: lokascript-i18n.min.js"
 
+      # `comprehensive` runs here rather than on a schedule: this job is already
+      # gated on `changes.outputs.code`, so the tier runs exactly when something
+      # that could break it changes and never on a quiet tree. It costs ~20s
+      # (122 specs) on a job that is not on the critical path.
+      #
+      # It was previously unrun ANYWHERE — `quick` is the only project CI
+      # invoked — and four real bugs shipped behind that gap: a detached
+      # `startViewTransition` (broken in every browser that has the API),
+      # untracked reads of unset globals, concurrent effects clobbering
+      # dependency capture, and `put` stringifying DocumentFragments (which
+      # silently broke the htmx-compat swap path). See #904 / #905.
       - name: Run Playwright tests
-        run: npx playwright test --project=quick
+        run: npx playwright test --project=quick --project=comprehensive
         working-directory: packages/core
 
       - name: Run htmx-adapter e2e (real htmx v4/v2 + _hyperscript)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,7 +339,7 @@ As of 2026-01-23, all CI testing has been consolidated into a single `.github/wo
 | 3    | `lint-typecheck`          | ✓   | —                 | —       | oxlint + TypeScript checks                                 |
 | 4    | `unit-tests`              | ✓   | —                 | —       | Vitest tests on Node 24 (27 packages)                      |
 | 5    | `coverage`                | —   | —                 | ✓       | Codecov upload; nightly since 2026-07-29 (was push+main)   |
-| 6    | `browser-tests`           | ✓   | —                 | —       | Playwright `--project=quick`; PR-only                      |
+| 6    | `browser-tests`           | ✓   | —                 | —       | Playwright `quick` + `comprehensive`; PR-only              |
 | 7    | `multilingual-validation` | ✓   | —                 | —       | 21-language full sweep + regression gate; PR-only          |
 | 8    | `bundle-size`             | ✓   | —                 | —       | Size report; PR-only (slim post-merge)                     |
 | 9    | `mcp-demos`               | ✓   | —                 | —       | Demo capture + drift check; PR-only                        |
@@ -350,6 +350,20 @@ As of 2026-01-23, all CI testing has been consolidated into a single `.github/wo
 The PR-only jobs already ran against the merged-as-PR code (`strict` branch protection means the PR validated the exact merged tree), so re-running them on the post-merge push would be redundant — the push run keeps only `build`. For the reasoning see the job comments in `.github/workflows/ci.yml`.
 
 `coverage` and `benchmarks` moved off push-to-main on **2026-07-29**: under `strict` protection the post-merge tree is the tree the PR validated, so `coverage` was re-executing the full core + semantic + i18n + language-server suites (430 files) a second time per merge purely for a Codecov datapoint. Neither is a required check (required = Build All Packages, Lint & Typecheck, Unit Tests, Export Validation, Multilingual Validation, Browser Tests), so nightly costs no gate strength. Same change fixed `benchmarks`, which ran `bench:run` (writes no file) and uploaded from a nonexistent `./core/benchmark-results/` — its output had always been discarded; it now runs `bench:ci` and uploads `packages/core/benchmark-results/`.
+
+`browser-tests` runs the `comprehensive` Playwright project alongside `quick` as of
+**2026-08-08**, and deliberately NOT on a schedule. Before that, `quick` was the only
+project CI ever invoked, so the 122 `@comprehensive` specs ran nowhere — `npm run
+test:comprehensive` had been failing on `main` with **four** real bugs behind it (a
+detached `startViewTransition`, untracked reads of unset globals, concurrent effects
+clobbering dependency capture, and `put` stringifying DocumentFragments, which silently
+broke the htmx-compat swap path — #904/#905). The job is already gated on
+`changes.outputs.code`, so the tier runs exactly when something that could break it
+changes and never on a quiet tree; both projects together take ~26s on a job that is not
+on the critical path (`build` is). A nightly was considered and rejected: the only thing a
+time-based run adds is drift from _outside_ the repo, and Playwright pins its browser
+binaries — so a Chromium change arrives via a `@playwright/test` bump, which is a code PR
+this gate already covers.
 
 **Triggers:**
 


### PR DESCRIPTION
Closes the gap that let four real bugs ship.

`browser-tests` invoked `--project=quick` and nothing else, so the 122 `@comprehensive` specs ran **nowhere** in CI. `npm run test:comprehensive` had been failing on `main` for some time, and behind those failures were four genuine product bugs — a detached `startViewTransition` (broken in every browser that *has* the API), reads of unset globals registering no reactive dependency, concurrent effects clobbering each other's dependency capture, and `put` stringifying DocumentFragments, which silently broke the htmx-compat layer's entire swap path. All four are fixed (#904, #905); this stops the class from recurring.

## Why here and not on a schedule

The job is **already** gated on `needs.changes.outputs.code`, so the tier runs exactly when something that could break it changes, and never on a quiet tree. That was the requirement — no nightly burning cycles against an unchanged repo.

A scheduled run was considered and rejected on its merits: the only thing a time-based run adds over PR-gating is drift from *outside* the repo. Playwright pins its browser binaries, so a Chromium change reaches us through a `@playwright/test` bump — a code PR, which this gate already covers. Guarding a nightly on "did the tree change" would also defeat its own purpose, since an unchanged tree is precisely the case it would exist for.

Adding it to the existing job rather than creating a new one also avoids a new entry in the six hand-maintained CI package lists (and their guard scripts).

## Cost

`--project=quick --project=comprehensive` together: **219 passed, 1 skipped, 25.8s** locally. The job currently runs ~2m6s and is not on the critical path — `build` at ~4m21s is — so PR wall-clock should be unchanged.

## Note on required-check risk

`Browser Tests` is a required check, so flakiness in the 122 added specs would block merges. They ran 122/122 clean across several local runs, and the four failures found were genuine bugs rather than flake, so I'd take that directly. If it proves noisy, the fallback is to split them into a separate non-required job and promote once quiet.

Also updates the CI job table and adds the rationale to `CLAUDE.md`, so the next person asking "why isn't this nightly?" finds the answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)