### PR TITLE
fix(semantic): qu take.recipient — the R1 tail's last take row, closed in the deferral's own filed order

### DIFF
--- a/docs-internal/MULTILINGUAL_NEXT_STEPS.md
+++ b/docs-internal/MULTILINGUAL_NEXT_STEPS.md
@@ -45,9 +45,20 @@
 > rendering change at all, which is the third time this arc's filed prescription
 > was falsified by triage. R1 tail **24 → 15**; **fourteen languages are now at
 > avgRoleFidelity 1.0000** — ar, bn, de, es, fr, hi, it, ja, pt, ru, sw, tl, tr,
-> uk. What remains: qu's `take.recipient` (blocked on a renderer defect, named
-> in that section) and 14 scattered singletons — the "thin and flat" headroom by
+> uk. What remains: ~~qu's `take.recipient` (blocked on a renderer defect, named
+> in that section)~~ and 14 scattered singletons — the "thin and flat" headroom by
 > design.
+>
+> **Update 2026-08-09 — the qu row is closed too (R1 tail 15 → 14; every
+> `take.recipient` row is now faithful).** Both halves of the named blocker
+> shipped: implicit-default tagging so the renderer suppresses only
+> matcher-injected `me` (authored `noqa man` / `to me` survives round-trips),
+> plus the `-sov-source-fronted` event-handler variant for qu's canonical
+> order. The R2 tabs flattening the deferral predicted did fire — via the
+> `includes('source')` delegation-threading gate matching the new pattern id,
+> now `endsWith('source')` — and was caught by the execution ratchet exactly as
+> designed. Detail in the take section's Resolution paragraph below. What
+> remains of the R1 tail is the 14 singletons only.
 
 ## Where we are (2026-07-20 baseline `82fb5827` · post pick-text-range arc 3 · `browser-priority`)
 
@@ -3030,7 +3041,8 @@ downstream symptom: the fused event-handler swap re-parses
 `[verb..clause boundary]` standalone and swaps the richer result in only when it
 is the SAME action, so an action flip vetoed the swap.
 
-**qu is deferred, with its blocker named.** A source-fronted pattern variant
+~~**qu is deferred, with its blocker named.**~~ **SHIPPED (2026-08-09).** A
+source-fronted pattern variant
 fixes it — measured: qu's take row AND `event-from-elsewhere` both go
 role-faithful, two more rows gain confidence. But it then wins on qu's compound
 rows, where the flattened body loses its `then` connectives and
@@ -3040,6 +3052,35 @@ renders as `add .active` in both states — the destination is captured and then
 dropped by the renderer — so the emitted English is only unambiguous while a
 `then` separates it from the preceding command. **Fix the dropped destination
 first**; the pattern variant is a few lines after that.
+
+**Resolution, in the filed order.** (1) The dropped destination was the
+renderer's blanket `me`-suppression compensating for matcher-materialized
+schema defaults — it could not tell authored `noqa man`/`to me` from injected
+`destination: me`. Injected defaults now carry `implicit: true` (SemanticValue
+`ImplicitTaggable`); the renderer suppresses ONLY those, so authored phrases
+survive round-trips (`translate('add .active to me','en','en')` is now a fixed
+point; the string-content carve-out was this same conflation patched narrowly
+and still stands for implicit values). (2) The
+`generateSOVPatientFirstSourceFrontedEventHandlerPattern` variant (required
+marked source slot between patient and event; self-gates on a source role +
+marker distinct from event/patient markers) covers qu's canonical order. The
+R2 flattening the deferral measured DID recur, via a different mechanism than
+the flattened-body ambiguity: the handler-level `source` threading gate was
+`id.includes('source')`, which the variant's mid-id `source` satisfied,
+delegating qu's tabs handlers to `.tab` — now `endsWith('source')`
+(handler-head patterns all end in `-source`), mutation-verified both ways.
+Whole-corpus probe (4150 rows incl. en): exactly 7 qu rows changed — take +
+event-from-elsewhere role-faithful, 5 compound/confidence gains, zero diffs
+elsewhere (signature includes eventModifiers). Full 11-signal gate green;
+baseline regenerated (qu drops `take-class-from-siblings` from
+`roleLossyPatterns` → **R1 tail 15 → 14, all take.recipient rows closed**; the
+regen also records pre-existing main-vs-baseline confidence drift: es
+set-family ×16 at 0.789 and qu remove-class rows, verified identical on a
+clean main worktree — not this change's doing). Downstream: the
+hyperscript-adapter full path now renders authored `from me` (4 corpus rows),
+a KNOWN, runtime-equivalent full-vs-slim divergence (slim has no
+authored/implicit distinction); the slim repeat-surface safety pin is now
+content-addressed instead of `KNOWN_DIVERGENCES[0]`.
 
 **A matcher defect found on the way, live in 90 shipped patterns.** Every
 `<cmd>-event-<lang>-sov` binds `destination` in BOTH a pre-verb and a post-verb

--- a/packages/hyperscript-adapter/test/fixtures/preprocessor-parity.json
+++ b/packages/hyperscript-adapter/test/fixtures/preprocessor-parity.json
@@ -68,25 +68,25 @@
   {
     "lang": "es",
     "input": "quitar .hidden de yo",
-    "full": "remove .hidden",
+    "full": "remove .hidden from me",
     "slim": "remove .hidden"
   },
   {
     "lang": "ja",
     "input": "自分 から .hidden を 削除",
-    "full": "remove .hidden",
+    "full": "remove .hidden from me",
     "slim": "remove .hidden"
   },
   {
     "lang": "ko",
     "input": "나 에서 .hidden 을 제거",
-    "full": "remove .hidden",
+    "full": "remove .hidden from me",
     "slim": "remove .hidden"
   },
   {
     "lang": "fr",
     "input": "supprimer .hidden de moi",
-    "full": "remove .hidden",
+    "full": "remove .hidden from me",
     "slim": "remove .hidden"
   },
   {

--- a/packages/hyperscript-adapter/test/parity-harness.ts
+++ b/packages/hyperscript-adapter/test/parity-harness.ts
@@ -151,5 +151,14 @@ export function loadFixture(): FixtureRow[] {
  *  row's output staying engine-invalid until the repeat surface is fixed
  *  whole (capture + SYNTAX render + me-suppression exception together). */
 export const KNOWN_DIVERGENCES: Array<[lang: string, input: string]> = [
+  // The full path keeps an AUTHORED `from me` (implicit-default tagging in
+  // @lokascript/semantic: only matcher-injected defaults are suppressed on
+  // render); the slim path has no parse-side authored/implicit distinction and
+  // still drops the phrase. Runtime-equivalent — upstream `remove .hidden`
+  // defaults its source to `me` — so slim's shorter form stays valid.
+  ['es', 'quitar .hidden de yo'],
+  ['ja', '自分 から .hidden を 削除'],
+  ['ko', '나 에서 .hidden 을 제거'],
+  ['fr', 'supprimer .hidden de moi'],
   ['es', 'en clic repetir 3 times entonces agregar "<p>Line</p>" a yo'],
 ];

--- a/packages/hyperscript-adapter/test/preprocessor-parity.slim.test.ts
+++ b/packages/hyperscript-adapter/test/preprocessor-parity.slim.test.ts
@@ -79,7 +79,11 @@ describe('remaining divergence stays behind the host-validate gate', () => {
       ._hyperscript;
     if (!hs?.parse) throw new Error('vendored _hyperscript did not expose parse()');
 
-    const [lang, input] = KNOWN_DIVERGENCES[0];
+    // Addressed by content, not index: KNOWN_DIVERGENCES is corpus-ordered and
+    // has since gained the authored-`from me` rows ahead of this one.
+    const repeatRow = KNOWN_DIVERGENCES.find(([, i]) => i.includes('repetir'));
+    if (!repeatRow) throw new Error('es repeat divergence row missing from KNOWN_DIVERGENCES');
+    const [lang, input] = repeatRow;
     const slimOut = preprocessToEnglish(input, lang, {});
     expect(slimOut).not.toBe(input); // the slim path DOES commit a translation…
     let errors: unknown[];

--- a/packages/hyperscript-adapter/test/preprocessor.test.ts
+++ b/packages/hyperscript-adapter/test/preprocessor.test.ts
@@ -34,9 +34,11 @@ describe('preprocessToEnglish', () => {
       ['ja', '自分 から .hidden を 削除'],
       ['ko', '나 에서 .hidden 을 제거'],
       ['fr', 'supprimer .hidden de moi'],
-    ])('[%s] translates remove .hidden (implicit me source suppressed)', (lang, input) => {
+    ])('[%s] translates remove .hidden (authored me source kept)', (lang, input) => {
+      // These inputs WRITE the source out (`de yo`, `自分 から`), so the render
+      // keeps it: only matcher-injected implicit defaults are suppressed.
       const result = preprocessToEnglish(input, lang);
-      expect(result).toBe('remove .hidden');
+      expect(result).toBe('remove .hidden from me');
     });
   });
 

--- a/packages/semantic/src/explicit/renderer.ts
+++ b/packages/semantic/src/explicit/renderer.ts
@@ -476,6 +476,11 @@ export class SemanticRendererImpl implements ISemanticRenderer {
             if (!roleToken) continue;
             const roleValue = node.roles.get(roleName);
             if (roleValue?.type !== 'reference' || roleValue.value !== 'me') continue;
+            // Only the matcher-materialized default is redundant. An AUTHORED
+            // `to me` / `from me` (qu `noqa man`, zh `给 我`) must survive the
+            // round-trip — dropping it made `add .active to me` and bare
+            // `add .active` render identically (#874's qu deferral blocker).
+            if (!roleValue.implicit) continue;
             // Keep an explicit destination when the patient is string content —
             // canonical `add "<p>Line</p>" to me` requires it (`add "<p>Line</p>"`
             // alone is rejected: `add` expects a class/attribute reference). A

--- a/packages/semantic/src/generators/event-handlers-sov.ts
+++ b/packages/semantic/src/generators/event-handlers-sov.ts
@@ -179,9 +179,10 @@ function appendOptionalTailRole(
     type: 'group',
     optional: true,
     tokens: [
-      ...(marker ? marker.split(/\s+/) : []).map(
-        (word): PatternToken => ({ type: 'literal', value: word })
-      ),
+      ...(marker ? marker.split(/\s+/) : []).map((word): PatternToken => ({
+        type: 'literal',
+        value: word,
+      })),
       {
         type: 'role',
         role,
@@ -409,6 +410,112 @@ export function generateSOVPatientFirstEventHandlerPattern(
     priority: (config.basePriority ?? 100) + 45,
     template: {
       format: `{patient} ${patientMarker?.primary || ''} {event} ${eventMarker.primary} ${keyword.primary}`,
+      tokens,
+    },
+    extraction,
+  };
+}
+
+/**
+ * Source-fronted patient-first SOV variant: the SOURCE phrase sits between the
+ * patient and the event, pre-verb —
+ *
+ *   [patient] [patMarker] [source] [srcMarker] [event] [eventMarker] [verb] [recipient?] [manner?]
+ *
+ * qu's canonical order fronts the source phrase for source-carrying commands:
+ * take `.active ta .tab-button manta ñitiy pi hapiy noqa`, remove
+ * `.open ta noqa manta ñitiy pi qichuy`. No other generated pattern covers the
+ * shape, so qu matched nothing and the verb-anchoring fallback bound the
+ * trailing pronoun to `destination` (#874's deferred third cause).
+ *
+ * The source slot is REQUIRED, marker and all: optional, this pattern is the
+ * plain patient-first pattern plus greedy-match ambiguity (the trap the
+ * WithDest variant documents); required, it competes only when a marked source
+ * phrase truly sits between patient and event. Not generated for `swap`
+ * (no source role, and its fronted slot binds `destination`).
+ */
+export function generateSOVPatientFirstSourceFrontedEventHandlerPattern(
+  commandSchema: CommandSchema,
+  profile: LanguageProfile,
+  keyword: KeywordTranslation,
+  eventMarker: RoleMarker,
+  config: GeneratorConfig
+): LanguagePattern | null {
+  const sourceSpec = commandSchema.roles.find(r => r.role === 'source');
+  if (!sourceSpec) return null;
+  const { marker: sourceMarker, alternatives: sourceAlts } = resolveRoleMarker(sourceSpec, profile);
+  const patientMarker = profile.roleMarkers.patient;
+  // A marked source slot is the variant's whole anchor — without a marker, or
+  // with one colliding with the event/patient markers, the shape is ambiguous.
+  if (!sourceMarker) return null;
+  if (sourceMarker === eventMarker.primary || sourceMarker === patientMarker?.primary) return null;
+
+  const tokens: PatternToken[] = [];
+
+  tokens.push({ type: 'role', role: 'patient', optional: false });
+  if (patientMarker) {
+    tokens.push(
+      patientMarker.alternatives
+        ? {
+            type: 'literal',
+            value: patientMarker.primary,
+            alternatives: patientMarker.alternatives,
+          }
+        : { type: 'literal', value: patientMarker.primary }
+    );
+  }
+
+  tokens.push({
+    type: 'role',
+    role: 'source',
+    optional: false,
+    ...(sourceSpec.expectedTypes ? { expectedTypes: sourceSpec.expectedTypes } : {}),
+    ...(sourceSpec.valueShape !== undefined ? { valueShape: sourceSpec.valueShape } : {}),
+  });
+  for (const word of sourceMarker.split(/\s+/)) {
+    tokens.push(
+      sourceAlts && sourceMarker.split(/\s+/).length === 1
+        ? { type: 'literal', value: word, alternatives: sourceAlts }
+        : { type: 'literal', value: word }
+    );
+  }
+
+  tokens.push({ type: 'role', role: 'event', optional: false });
+  if (eventMarker.position === 'after') {
+    const markerWords = eventMarker.primary.split(/\s+/);
+    if (markerWords.length > 1) {
+      for (const word of markerWords) tokens.push({ type: 'literal', value: word });
+    } else {
+      tokens.push(
+        eventMarker.alternatives
+          ? { type: 'literal', value: eventMarker.primary, alternatives: eventMarker.alternatives }
+          : { type: 'literal', value: eventMarker.primary }
+      );
+    }
+  }
+
+  tokens.push(
+    keyword.alternatives
+      ? { type: 'literal', value: keyword.primary, alternatives: keyword.alternatives }
+      : { type: 'literal', value: keyword.primary }
+  );
+
+  const extraction: Record<string, ExtractionRule> = {
+    action: { value: commandSchema.action },
+    event: { fromRole: 'event' },
+    patient: { fromRole: 'patient' },
+    source: { fromRole: 'source' },
+  };
+  appendOptionalRecipient(tokens, extraction, commandSchema, profile.code);
+  appendOptionalViewTransition(tokens, extraction, commandSchema, profile.code);
+
+  return {
+    id: `${commandSchema.action}-event-${profile.code}-sov-source-fronted`,
+    language: profile.code,
+    command: 'on',
+    priority: (config.basePriority ?? 100) + 48,
+    template: {
+      format: `{patient} ${patientMarker?.primary || ''} {source} ${sourceMarker} {event} ${eventMarker.primary} ${keyword.primary}`,
       tokens,
     },
     extraction,

--- a/packages/semantic/src/generators/pattern-generator.ts
+++ b/packages/semantic/src/generators/pattern-generator.ts
@@ -19,6 +19,7 @@ import { resolveMarkerForRole, schemaMarkerAlternatives } from '../parser/utils/
 import {
   generateSOVEventHandlerPattern,
   generateSOVPatientFirstEventHandlerPattern,
+  generateSOVPatientFirstSourceFrontedEventHandlerPattern,
   generateSOVPatientFirstWithDestEventHandlerPattern,
   generateSOVCompactEventHandlerPattern,
   generateSOVSimpleEventHandlerPattern,
@@ -492,6 +493,19 @@ export function generateEventHandlerPatterns(
           config
         )
       );
+
+      // Variant 1b: Source-fronted (source phrase between patient and event,
+      // both required) — qu's canonical order for source-carrying commands
+      // (take/remove). Self-gates: null unless the schema has a source role
+      // with a usable marker distinct from the event/patient markers.
+      const sourceFronted = generateSOVPatientFirstSourceFrontedEventHandlerPattern(
+        commandSchema,
+        profile,
+        keyword,
+        eventMarker,
+        config
+      );
+      if (sourceFronted) patterns.push(sourceFronted);
 
       // Variant 2: With destination (required, not optional) — lower priority
       // Only add if destination marker differs from event marker to avoid collision

--- a/packages/semantic/src/parser/pattern-matcher.ts
+++ b/packages/semantic/src/parser/pattern-matcher.ts
@@ -982,7 +982,10 @@ export class PatternMatcher {
     // `expectedTypes` validation, so no type-compatibility or adoption decision
     // can move — the slot still admits both types, it just reports one.
     if (patternToken.valueShape === 'keyword' && value.type === 'expression') {
-      captured.set(patternToken.role, createLiteral(String((value as { raw?: unknown }).raw ?? '')));
+      captured.set(
+        patternToken.role,
+        createLiteral(String((value as { raw?: unknown }).raw ?? ''))
+      );
     } else {
       captured.set(patternToken.role, value);
     }
@@ -2808,7 +2811,10 @@ export class PatternMatcher {
         // Static value extraction (e.g., action: { value: "toggle" })
         captured.set(role as SemanticRole, { type: 'literal', value: rule.value });
       } else if (rule.default) {
-        captured.set(role as SemanticRole, rule.default);
+        // Copied, never aliased (the rule's default object is shared across
+        // parses), and tagged implicit: materialized from the default, not
+        // captured from source text — renderers suppress implicit values only.
+        captured.set(role as SemanticRole, { ...rule.default, implicit: true });
       }
     }
   }

--- a/packages/semantic/src/parser/semantic-parser.ts
+++ b/packages/semantic/src/parser/semantic-parser.ts
@@ -585,7 +585,7 @@ export function fillSchemaDefaults(node: SemanticNode): SemanticNode {
       const roles = node.roles as Map<SemanticRole, SemanticValue>;
       for (const spec of schema.roles) {
         if (spec.default !== undefined && !roles.has(spec.role)) {
-          roles.set(spec.role, { ...spec.default } as SemanticValue);
+          roles.set(spec.role, { ...spec.default, implicit: true } as SemanticValue);
         }
       }
     }
@@ -1692,19 +1692,22 @@ export class SemanticParserImpl implements ISemanticParser {
     // builder already declare for exactly this meaning; until now nothing
     // ever populated it.
     // Gated to patterns whose id declares a handler-head source group
-    // (event-en-source and kin): the fused generated patterns also bind a
-    // `source` group — as a DEFAULT-filled reference `me`, or worse, by
-    // swallowing a BODY command's from-phrase (`remove .active from all
-    // .tab` → source=.tab) — and threading those turns a formerly-harmless
-    // dropped mis-capture into a live delegation filter (the tabs-basic /
-    // tabs-content / remove-class-from-all R2 regression, 59 curated rows,
-    // caught by the execution ratchet mid-arc). Translated window-resize
-    // renders get their from via reclaimDanglingFromTail instead, which
-    // never routes through here.
+    // (event-en-source and kin — all of them END in `-source`): the fused
+    // generated patterns also bind a `source` group — as a DEFAULT-filled
+    // reference `me`, or worse, by swallowing a BODY command's from-phrase
+    // (`remove .active from all .tab` → source=.tab) — and threading those
+    // turns a formerly-harmless dropped mis-capture into a live delegation
+    // filter (the tabs-basic / tabs-content / remove-class-from-all R2
+    // regression, 59 curated rows, caught by the execution ratchet mid-arc;
+    // then again via `-sov-source-fronted`, whose mid-id `source` satisfied
+    // the old includes() check and delegated qu's tabs handlers to `.tab` —
+    // that source is the BODY command's, hence endsWith). Translated
+    // window-resize renders get their from via reclaimDanglingFromTail
+    // instead, which never routes through here.
     const sourceValue = match.captured.get('source');
     if (
       sourceValue &&
-      match.pattern.id.includes('source') &&
+      match.pattern.id.endsWith('source') &&
       !(sourceValue.type === 'reference' && sourceValue.value === 'me')
     ) {
       eventModifiers = { ...(eventModifiers ?? {}), from: sourceValue };

--- a/packages/semantic/src/types.ts
+++ b/packages/semantic/src/types.ts
@@ -132,36 +132,46 @@ export type SemanticValue =
   LiteralValue | SelectorValue | ReferenceValue | PropertyPathValue | ExpressionValue | FlagValue;
 
 /**
+ * Set on a value the parser injected from a schema/extraction-rule `default`
+ * rather than captured from the source text. Renderers suppress implicit
+ * values (they were never written); authored values must survive round-trips
+ * — `add .active to me` renders its `to me`, bare `add .active` stays bare.
+ */
+export interface ImplicitTaggable {
+  readonly implicit?: true;
+}
+
+/**
  * Expected value types for role tokens.
  * Shared between RoleSpec (command-schemas) and RolePatternToken.
  */
 export type ExpectedType = SemanticValue['type'];
 
-export interface LiteralValue {
+export interface LiteralValue extends ImplicitTaggable {
   readonly type: 'literal';
   readonly value: string | number | boolean;
   readonly dataType?: 'string' | 'number' | 'boolean' | 'duration';
 }
 
-export interface SelectorValue {
+export interface SelectorValue extends ImplicitTaggable {
   readonly type: 'selector';
   readonly value: string; // The CSS selector: #id, .class, [attr], etc.
   readonly selectorKind: 'id' | 'class' | 'attribute' | 'element' | 'complex';
 }
 
-export interface ReferenceValue {
+export interface ReferenceValue extends ImplicitTaggable {
   readonly type: 'reference';
   readonly value:
     'me' | 'you' | 'it' | 'result' | 'event' | 'target' | 'body' | 'document' | 'window' | 'detail';
 }
 
-export interface PropertyPathValue {
+export interface PropertyPathValue extends ImplicitTaggable {
   readonly type: 'property-path';
   readonly object: SemanticValue;
   readonly property: string;
 }
 
-export interface ExpressionValue {
+export interface ExpressionValue extends ImplicitTaggable {
   readonly type: 'expression';
   /** Raw expression string for complex expressions that need further parsing */
   readonly raw: string;
@@ -171,7 +181,7 @@ export interface ExpressionValue {
  * A boolean flag value — present (+flag) or negated (~flag).
  * Used in declarative domains for no-value attributes like primary-key, not-null.
  */
-export interface FlagValue {
+export interface FlagValue extends ImplicitTaggable {
   readonly type: 'flag';
   readonly name: string;
   readonly enabled: boolean;

--- a/packages/semantic/test/implicit-default-rendering.test.ts
+++ b/packages/semantic/test/implicit-default-rendering.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Implicit-default tagging + the qu source-fronted event variant (#874's
+ * deferred third cause, both halves).
+ *
+ * Renderer half: the matcher materializes schema/extraction `default`s into
+ * the captured roles (`add .active` parses with destination=me), so the
+ * renderer suppressed EVERY destination/source `me` — including authored ones.
+ * `add .active to me` and `add .active` rendered identically, which is the
+ * ambiguity #874 named as the blocker for qu's compound rows. Injected
+ * defaults now carry `implicit: true` and only those are suppressed: authored
+ * phrases survive round-trips, bare surfaces stay bare.
+ *
+ * Parser half: qu's canonical order fronts the source phrase
+ * (`.active ta .tab-button manta ñitiy pi hapiy noqa`), a shape no pattern
+ * covered — the `-sov-source-fronted` variant matches it. Its captured
+ * `source` belongs to the BODY command, so it must NOT thread into
+ * eventModifiers.from (delegation): the threading gate is endsWith('source'),
+ * and the fused variant's mid-id `source` must not satisfy it. That exact
+ * mistake (includes() matching `-sov-source-fronted`) delegated qu's tabs
+ * handlers to `.tab` and reddened R2 tabs-basic/tabs-content at tolerance 0.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseSemantic, translate } from '../src/index';
+import { buildAST } from '../src/ast-builder/index';
+
+describe('authored vs implicit me — render round-trips are fixed points', () => {
+  it.each([
+    ['add .active', 'add .active'],
+    ['add .active to me', 'add .active to me'],
+    ['remove me', 'remove me'],
+    ['remove .open from me', 'remove .open from me'],
+    ['toggle .active', 'toggle .active'],
+    ['toggle .active on me', 'toggle .active on me'],
+  ])('en→en %s → %s', (input, expected) => {
+    expect(translate(input, 'en', 'en')).toBe(expected);
+  });
+
+  it('the matcher tags a default-filled destination implicit; an authored one not', () => {
+    const bare = parseSemantic('add .active', 'en');
+    const authored = parseSemantic('add .active to me', 'en');
+    const bareDest = bare.node?.roles.get('destination');
+    const authoredDest = authored.node?.roles.get('destination');
+    expect(bareDest?.value).toBe('me');
+    expect(bareDest?.implicit).toBe(true);
+    expect(authoredDest?.value).toBe('me');
+    expect(authoredDest?.implicit).toBeUndefined();
+  });
+
+  it('qu: authored `noqa man` (to me) survives the English render', () => {
+    // Before the tagging, this rendered `add .active` — indistinguishable from
+    // the bare surface, ambiguous once compound bodies lose their connectives.
+    expect(translate('.active ta noqa man yapay', 'qu', 'en')).toBe('add .active to me');
+  });
+});
+
+describe('qu source-fronted fused variant — body source is not delegation', () => {
+  const TABS_BASIC = '.active ta .tab manta ñitiy pi qichuy chayqa .active ta noqa man yapay';
+
+  it('matches the fused compound row with both body commands intact', () => {
+    const p = parseSemantic(TABS_BASIC, 'qu');
+    expect(p.confidence).toBe(1);
+    const handler = p.node as unknown as {
+      body?: Array<{ action: string; roles: Map<string, { value?: unknown }> }>;
+      eventModifiers?: { from?: unknown };
+    };
+    expect(handler.body?.map(c => c.action)).toEqual(['remove', 'add']);
+    // The remove's from-phrase stays ON the remove…
+    expect(handler.body?.[0].roles.get('source')?.value).toBe('.tab');
+    // …and never becomes the handler's delegation filter. endsWith('source')
+    // is the load-bearing check: includes() re-reddens this line.
+    expect(handler.eventModifiers?.from).toBeUndefined();
+  });
+
+  it('builds an eventHandler AST with no delegation target', () => {
+    const p = parseSemantic(TABS_BASIC, 'qu');
+    const built = buildAST(p.node!);
+    const ast = built.ast as { selector?: string; target?: string; commands?: unknown[] };
+    expect(ast.selector).toBeUndefined();
+    expect(ast.target).toBeUndefined();
+    expect(ast.commands).toHaveLength(2);
+  });
+
+  it('handler-head source patterns still thread delegation (negative control)', () => {
+    // `on click from .menu …` — a REAL delegation phrase must keep threading
+    // through the endsWith('source') gate.
+    const p = parseSemantic('on click from .menu toggle .open', 'en');
+    const handler = p.node as unknown as { eventModifiers?: { from?: { value?: unknown } } };
+    expect(handler.eventModifiers?.from?.value).toBe('.menu');
+  });
+});

--- a/packages/semantic/test/take-recipient.test.ts
+++ b/packages/semantic/test/take-recipient.test.ts
@@ -273,18 +273,21 @@ describe('the three causes behind the 10, pinned directly', () => {
     expect(walkCommands(parse(source, lang)).map(c => c.action), `${lang}`).toEqual(['get']);
   });
 
-  it('qu still binds the pronoun to destination — the one language not fixed', () => {
-    // Pinning the CURRENT measured state and its cause, not a desired one: qu
-    // matches no pattern for this surface (its canonical order fronts the source
-    // phrase), so verb-anchoring assigns the trailing pronoun. See the header
-    // for why the pattern variant that fixes it is blocked on a renderer defect.
+  it('qu captures the recipient — the source-fronted variant covers its canonical order', () => {
+    // qu's canonical order fronts the source phrase (`.active ta .tab-button
+    // manta ñitiy pi hapiy noqa`), a shape no pattern covered, so this test used
+    // to pin the DEFECT: verb-anchoring bound the trailing pronoun to
+    // `destination`. The `-sov-source-fronted` event-handler variant (required
+    // marked source slot between patient and event) now matches it, and the
+    // renderer half of the blocker — authored `to me` dropped on render — is
+    // fixed via implicit-default tagging.
     const node = walkCommands(
       parse('.active ta .tab-button manta ñitiy pi hapiy noqa', 'qu')
     )[0] as unknown as CommandSemanticNode;
     expect(roleValue(node, 'patient')).toBe('.active');
     expect(roleValue(node, 'source')).toBe('.tab-button');
-    expect(node.roles.has('recipient' as never)).toBe(false);
-    expect(roleValue(node, 'destination')).toBe('me');
+    expect(roleValue(node, 'recipient')).toBe('me');
+    expect(node.roles.has('destination' as never)).toBe(false);
   });
 
   it('a failed optional group cannot corrupt an already-captured role', () => {

--- a/packages/testing-framework/baselines/multilingual-priority.json
+++ b/packages/testing-framework/baselines/multilingual-priority.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-08-01T19:11:38.421Z",
-  "commit": "fa3a1890",
+  "timestamp": "2026-08-09T18:36:43.252Z",
+  "commit": "d8911080",
   "languages": {
     "ar": {
       "parseSuccess": 156,
@@ -17,7 +17,7 @@
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [],
-      "bundleSize": 559592,
+      "bundleSize": 561448,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -660,7 +660,7 @@
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [],
-      "bundleSize": 559592,
+      "bundleSize": 561448,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1303,7 +1303,7 @@
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [],
-      "bundleSize": 559592,
+      "bundleSize": 561448,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -1936,7 +1936,7 @@
       "parseFailure": 0,
       "parseRate": 1,
       "avgConfidence": 1,
-      "bundleSize": 559592,
+      "bundleSize": 561448,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -2568,7 +2568,7 @@
       "parseSuccess": 156,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.8352055352055331,
+      "avgConfidence": 0.8136130925604584,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
@@ -2579,7 +2579,7 @@
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [],
-      "bundleSize": 559592,
+      "bundleSize": 561448,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -2590,18 +2590,6 @@
           "confidence": 1
         },
         "add-class-to-other": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-text-basic": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-attribute": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-style": {
           "success": true,
           "confidence": 1
         },
@@ -2669,14 +2657,6 @@
           "success": true,
           "confidence": 1
         },
-        "input-char-count": {
-          "success": true,
-          "confidence": 1
-        },
-        "input-clear": {
-          "success": true,
-          "confidence": 1
-        },
         "form-disable-on-submit": {
           "success": true,
           "confidence": 1
@@ -2686,14 +2666,6 @@
           "confidence": 1
         },
         "window-scroll": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-opacity": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-transform": {
           "success": true,
           "confidence": 1
         },
@@ -2749,27 +2721,11 @@
           "success": true,
           "confidence": 1
         },
-        "two-way-binding": {
-          "success": true,
-          "confidence": 1
-        },
-        "computed-value": {
-          "success": true,
-          "confidence": 1
-        },
         "toggle-aria-expanded": {
           "success": true,
           "confidence": 1
         },
         "announce-screen-reader": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-text-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "set-inner-html-possessive-dot": {
           "success": true,
           "confidence": 1
         },
@@ -2781,19 +2737,7 @@
           "success": true,
           "confidence": 1
         },
-        "chained-access-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
         "get-attribute-possessive-dot": {
-          "success": true,
-          "confidence": 1
-        },
-        "template-literal-interpolation": {
-          "success": true,
-          "confidence": 1
-        },
-        "template-literal-list-build": {
           "success": true,
           "confidence": 1
         },
@@ -2822,10 +2766,6 @@
           "confidence": 1
         },
         "breakpoint-command": {
-          "success": true,
-          "confidence": 1
-        },
-        "beep-debug-expression": {
           "success": true,
           "confidence": 1
         },
@@ -2861,10 +2801,6 @@
           "success": true,
           "confidence": 1
         },
-        "caret-var-write": {
-          "success": true,
-          "confidence": 1
-        },
         "caret-var-on-target": {
           "success": true,
           "confidence": 1
@@ -2892,6 +2828,70 @@
         "install-behavior": {
           "success": true,
           "confidence": 0.8222222222222222
+        },
+        "set-text-basic": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
+        "set-attribute": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
+        "set-style": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
+        "input-char-count": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
+        "input-clear": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
+        "set-opacity": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
+        "set-transform": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
+        "two-way-binding": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
+        "computed-value": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
+        "set-text-possessive-dot": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
+        "set-inner-html-possessive-dot": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
+        "chained-access-possessive-dot": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
+        "template-literal-interpolation": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
+        "template-literal-list-build": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
+        "beep-debug-expression": {
+          "success": true,
+          "confidence": 0.7894736842105263
+        },
+        "caret-var-write": {
+          "success": true,
+          "confidence": 0.7894736842105263
         },
         "remove-class-basic": {
           "success": true,
@@ -3222,7 +3222,7 @@
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [],
-      "bundleSize": 559592,
+      "bundleSize": 561448,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -3864,10 +3864,8 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "set-attribute"
-      ],
-      "bundleSize": 559592,
+      "roleLossyPatterns": ["set-attribute"],
+      "bundleSize": 561448,
       "patterns": {
         "put-content-basic": {
           "success": true,
@@ -4510,7 +4508,7 @@
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [],
-      "bundleSize": 559592,
+      "bundleSize": 561448,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5152,12 +5150,8 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "fetch-do-not-throw",
-        "fetch-error-handling",
-        "fetch-json"
-      ],
-      "bundleSize": 559592,
+      "roleLossyPatterns": ["fetch-do-not-throw", "fetch-error-handling", "fetch-json"],
+      "bundleSize": 561448,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -5800,7 +5794,7 @@
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [],
-      "bundleSize": 559592,
+      "bundleSize": 561448,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -6443,7 +6437,7 @@
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [],
-      "bundleSize": 559592,
+      "bundleSize": 561448,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7085,11 +7079,8 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "when-multiple-changes",
-        "when-value-changes"
-      ],
-      "bundleSize": 559592,
+      "roleLossyPatterns": ["when-multiple-changes", "when-value-changes"],
+      "bundleSize": 561448,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -7731,10 +7722,8 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "hide-with-transition"
-      ],
-      "bundleSize": 559592,
+      "roleLossyPatterns": ["hide-with-transition"],
+      "bundleSize": 561448,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -8376,10 +8365,8 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "unless-condition"
-      ],
-      "bundleSize": 559592,
+      "roleLossyPatterns": ["unless-condition"],
+      "bundleSize": 561448,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9022,7 +9009,7 @@
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [],
-      "bundleSize": 559592,
+      "bundleSize": 561448,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9654,22 +9641,18 @@
       "parseSuccess": 156,
       "parseFailure": 0,
       "parseRate": 1,
-      "avgConfidence": 0.7426027676027677,
+      "avgConfidence": 0.7714489214489215,
       "avgFidelity": 1,
       "avgPrecision": 1,
       "avgMultisetRecall": 1,
-      "avgRoleFidelity": 0.9961751152073733,
+      "avgRoleFidelity": 0.9974654377880184,
       "avgValueRecall": 1,
       "avgExecutionFidelity": 1,
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "announce-screen-reader",
-        "on-custom-event-receive",
-        "take-class-from-siblings"
-      ],
-      "bundleSize": 559592,
+      "roleLossyPatterns": ["announce-screen-reader", "on-custom-event-receive"],
+      "bundleSize": 561448,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -9680,6 +9663,14 @@
           "confidence": 1
         },
         "add-class-to-other": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-class-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "remove-class-from-all": {
           "success": true,
           "confidence": 1
         },
@@ -9783,6 +9774,14 @@
           "success": true,
           "confidence": 1
         },
+        "tabs-basic": {
+          "success": true,
+          "confidence": 1
+        },
+        "tabs-content": {
+          "success": true,
+          "confidence": 1
+        },
         "modal-open": {
           "success": true,
           "confidence": 1
@@ -9799,7 +9798,15 @@
           "success": true,
           "confidence": 1
         },
+        "accordion-exclusive": {
+          "success": true,
+          "confidence": 1
+        },
         "dropdown-toggle": {
+          "success": true,
+          "confidence": 1
+        },
+        "dropdown-close-outside": {
           "success": true,
           "confidence": 1
         },
@@ -9816,6 +9823,10 @@
           "confidence": 1
         },
         "next-element": {
+          "success": true,
+          "confidence": 1
+        },
+        "previous-element": {
           "success": true,
           "confidence": 1
         },
@@ -9836,6 +9847,10 @@
           "confidence": 1
         },
         "event-once": {
+          "success": true,
+          "confidence": 1
+        },
+        "event-from-elsewhere": {
           "success": true,
           "confidence": 1
         },
@@ -9904,6 +9919,10 @@
           "confidence": 1
         },
         "breakpoint-command": {
+          "success": true,
+          "confidence": 1
+        },
+        "take-class-from-siblings": {
           "success": true,
           "confidence": 1
         },
@@ -10027,14 +10046,6 @@
           "success": true,
           "confidence": 0.5555555555555556
         },
-        "remove-class-basic": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "remove-class-from-all": {
-          "success": true,
-          "confidence": 0.5
-        },
         "set-text-basic": {
           "success": true,
           "confidence": 0.5
@@ -10091,27 +10102,11 @@
           "success": true,
           "confidence": 0.5
         },
-        "tabs-basic": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "tabs-content": {
-          "success": true,
-          "confidence": 0.5
-        },
         "tabs-aria": {
           "success": true,
           "confidence": 0.5
         },
         "modal-close-escape": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "accordion-exclusive": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "dropdown-close-outside": {
           "success": true,
           "confidence": 0.5
         },
@@ -10159,10 +10154,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "previous-element": {
-          "success": true,
-          "confidence": 0.5
-        },
         "first-in-parent": {
           "success": true,
           "confidence": 0.5
@@ -10176,10 +10167,6 @@
           "confidence": 0.5
         },
         "event-throttle": {
-          "success": true,
-          "confidence": 0.5
-        },
-        "event-from-elsewhere": {
           "success": true,
           "confidence": 0.5
         },
@@ -10263,10 +10250,6 @@
           "success": true,
           "confidence": 0.5
         },
-        "take-class-from-siblings": {
-          "success": true,
-          "confidence": 0.5
-        },
         "caret-var-write": {
           "success": true,
           "confidence": 0.5
@@ -10312,7 +10295,7 @@
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [],
-      "bundleSize": 559592,
+      "bundleSize": 561448,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -10955,7 +10938,7 @@
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [],
-      "bundleSize": 559592,
+      "bundleSize": 561448,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -11597,10 +11580,8 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "toggle-aria-expanded"
-      ],
-      "bundleSize": 559592,
+      "roleLossyPatterns": ["toggle-aria-expanded"],
+      "bundleSize": 561448,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12243,7 +12224,7 @@
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [],
-      "bundleSize": 559592,
+      "bundleSize": 561448,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -12886,7 +12867,7 @@
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [],
-      "bundleSize": 559592,
+      "bundleSize": 561448,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -13529,7 +13510,7 @@
       "degeneratePasses": [],
       "lossyPasses": [],
       "roleLossyPatterns": [],
-      "bundleSize": 559592,
+      "bundleSize": 561448,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14171,10 +14152,8 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "its-value-possessive-dot"
-      ],
-      "bundleSize": 559592,
+      "roleLossyPatterns": ["its-value-possessive-dot"],
+      "bundleSize": 561448,
       "patterns": {
         "toggle-class-on-other": {
           "success": true,
@@ -14816,11 +14795,8 @@
       "executionFailures": [],
       "degeneratePasses": [],
       "lossyPasses": [],
-      "roleLossyPatterns": [
-        "repeat-forever",
-        "repeat-until-event"
-      ],
-      "bundleSize": 559592,
+      "roleLossyPatterns": ["repeat-forever", "repeat-until-event"],
+      "bundleSize": 561448,
       "patterns": {
         "toggle-class-basic": {
           "success": true,
@@ -15451,20 +15427,8 @@
   },
   "bundles": {
     "browser-priority": {
-      "size": 559592,
-      "languages": [
-        "en",
-        "es",
-        "pt",
-        "fr",
-        "de",
-        "ja",
-        "zh",
-        "ko",
-        "ar",
-        "tr",
-        "id"
-      ]
+      "size": 561448,
+      "languages": ["en", "es", "pt", "fr", "de", "ja", "zh", "ko", "ar", "tr", "id"]
     }
   }
 }


### PR DESCRIPTION
## What

#874 closed 9 of the 10 `take.recipient` rows and deferred **qu** with its blocker named: *"qu's `add .active to me` renders as `add .active` in both states — the destination is captured and then dropped by the renderer. Fix the dropped destination first; the pattern variant is a few lines after that."* This PR does exactly that, in that order, and closes the last `take.recipient` row — **R1 tail 15 → 14** (the 14 scattered singletons are all that remain).

### 1. The dropped destination was not qu-specific

`translate('add .active to me','en','en')` emitted `add .active`. The matcher materializes schema/extraction defaults into captured roles (bare `agregar .active` parses with `destination=me`), so the renderer suppressed EVERY destination/source `me` — authored and injected alike. The string-content carve-out in `renderer.ts` was this same conflation patched narrowly. Injected defaults now carry `implicit: true` (`SemanticValue` gains `ImplicitTaggable`; `pattern-matcher` also stops **aliasing** the shared default object) and suppression fires only for implicit values. All six en round-trips in the new pin file are now fixed points; bare surfaces stay bare.

### 2. The source-fronted SOV event-handler variant

`generateSOVPatientFirstSourceFrontedEventHandlerPattern` covers qu's canonical order (`.active ta .tab-button manta ñitiy pi hapiy noqa` — patient, marked source, event, verb, bare recipient). Required marked source slot per the WithDest variant's greedy-match lesson; self-gates on a schema source role plus a marker distinct from event/patient markers, so no language without the shape gains a pattern.

### 3. The R2 flattening #874 predicted DID recur — via a different mechanism than filed

The handler-level `source`→`eventModifiers.from` threading gate was `id.includes('source')`, written to admit the hand-written handler-head patterns (all of which END in `-source`). The new variant's mid-id `source` satisfied it and delegated qu's tabs handlers to `.tab` — **R2 tabs-basic/tabs-content reddened at tolerance 0, caught by the execution ratchet exactly as designed**. The gate is now `endsWith('source')`; a future miss fails toward a dropped delegation value, not a wrong one.

## Measurements

- **Whole-corpus probe** (4150 stored rows incl. en, signature includes eventModifiers, clean main worktree vs branch): **exactly 7 qu rows differ** — `take-class-from-siblings` destination→recipient (role-faithful), `event-from-elsewhere` regains its dropped `source=me`, and 5 rows (`tabs-basic`, `tabs-content`, `accordion-exclusive`, `dropdown-close-outside`, `previous-element`) go 0.75→1.0 confidence with identical roles. Zero diffs in the other 23 languages.
- **Mutation-verified both ways**: `includes('source')` reddens exactly the two delegation pins; dropping the matcher's implicit tag reddens exactly the four round-trip fixed points; the old qu defect pin (`destination=me`, no recipient) reddened on the fix and is inverted.
- **Baseline regen** (fresh populate): qu drops `take-class-from-siblings` from `roleLossyPatterns`; qu avgRoleFidelity 0.99618 → 0.99747. The regen also records **pre-existing** main-vs-baseline drift (es set-family confidence ×16 at 0.789, qu remove-class rows, +1.8 KB bundle) — verified identical on a clean main worktree, i.e. accumulated since the 2026-08-01 baseline, not caused here.

## Downstream

hyperscript-adapter's full path now keeps an AUTHORED `from me` (4 parity corpus rows, es/ja/ko/fr) — a KNOWN, runtime-equivalent full-vs-slim divergence (slim has no authored/implicit distinction; upstream `remove .hidden` defaults its source to `me`). The slim repeat-surface safety pin is content-addressed now instead of `KNOWN_DIVERGENCES[0]`.

## Gates

multilingual `--full --regression` green (all 11 signals, real exit code) · semantic 7713 · hyperscript-adapter 366 · testing-framework 280 · root `test:check` 25 suites green · vocab validate 0 unwaived · typecheck clean (semantic, hyperscript-adapter). `patterns.db` deliberately not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)